### PR TITLE
Fix stack overflow in StaticModelUtil.weightsToProbabilities

### DIFF
--- a/stats/src/main/java/com/facebook/stats/cardinality/SortedStaticModel.java
+++ b/stats/src/main/java/com/facebook/stats/cardinality/SortedStaticModel.java
@@ -47,7 +47,7 @@ class SortedStaticModel implements Model {
     countsByIndex = new int[weights.length + 1];
     totalIndex = weights.length;
 
-    double[] probabilities = weightsToProbabilities(weights);
+    double[] probabilities = weightsToProbabilities(weights, 10);
     List<SymbolProbability> symbolProbabilities = sortProbabilities(probabilities);
 
     int symbolIndex = 0;

--- a/stats/src/main/java/com/facebook/stats/cardinality/StaticModel.java
+++ b/stats/src/main/java/com/facebook/stats/cardinality/StaticModel.java
@@ -38,7 +38,7 @@ class StaticModel implements Model {
     counts = new int[weights.length + 1];
     totalIndex = weights.length;
 
-    double[] probabilities = weightsToProbabilities(weights);
+    double[] probabilities = weightsToProbabilities(weights, 10);
 
     for (int symbol = 0; symbol < probabilities.length; symbol++) {
       double probability = probabilities[symbol];


### PR DESCRIPTION
Converts StaticModelUtil.weightsToProbabilities() recursion into a loop.  Also adds the ability to limit the number of iterations, and makes use of that limit in StaticModel and SortedStaticModel.

Strictly speaking, this is not backwards compatible, since StaticModel and SortedStaticModel no longer have exactly the same state.
