### PR TITLE
Use long for TimeInterval.length in jackson serialization/deserialization

### DIFF
--- a/util/src/main/java/com/facebook/util/TimeInterval.java
+++ b/util/src/main/java/com/facebook/util/TimeInterval.java
@@ -99,7 +99,7 @@ public class TimeInterval {
   @JsonCreator
   private static TimeInterval fromJson(
     @JsonProperty("type") TimeIntervalType type,
-    @JsonProperty("length") int length
+    @JsonProperty("length") long length
   ) {
     if (type == null) {
       if (length == 0) {

--- a/util/src/test/java/com/facebook/util/TestTimeIntervalSerialization.java
+++ b/util/src/test/java/com/facebook/util/TestTimeIntervalSerialization.java
@@ -49,7 +49,8 @@ public class TestTimeIntervalSerialization {
       {TimeInterval.withTypeAndLength(TimeIntervalType.WEEK, 1)},
       {TimeInterval.withTypeAndLength(TimeIntervalType.MONTH, 1)},
       {TimeInterval.withTypeAndLength(TimeIntervalType.MONTH, 12)},
-      {TimeInterval.withTypeAndLength(TimeIntervalType.YEAR, 1)}
+      {TimeInterval.withTypeAndLength(TimeIntervalType.YEAR, 1)},
+      {TimeInterval.withMillis(2592000000L)}
     };
   }
 


### PR DESCRIPTION
Summary:
SAT, TimeInterval.length may exceed max int value.

Test Plan: added unit test, existing tests pass
