### PR TITLE
package jcommon-all in a jar instead of a pom

### DIFF
--- a/jcommon-all/pom.xml
+++ b/jcommon-all/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   </parent>
 
   <artifactId>jcommon-all</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <name>jcommon-all</name>
 
   <properties>


### PR DESCRIPTION
It might be something new I haven't learned about maven, but it seems like just a type in the POM: you can't consume java classes from a binary .pom right?

Another thing not addressed here, but something we should think about is, do we want jcommon-all to contain all classes from all jcommon artifacts in one jar, or do we want it to contain that plus all dependencies of those too? Right now it contains all jcommon classes and all dependencies.
