### PR TITLE
Package classes for jcommon-all in a jar instead of a pom

### DIFF
--- a/jcommon-all/pom.xml
+++ b/jcommon-all/pom.xml
@@ -26,7 +26,7 @@ limitations under the License.
   </parent>
 
   <artifactId>jcommon-all</artifactId>
-  <packaging>pom</packaging>
+  <packaging>jar</packaging>
   <name>jcommon-all</name>
 
   <properties>
@@ -74,6 +74,16 @@ limitations under the License.
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <!-- maven-shade-plugin complains if there is nothing generated for
+               the main artifact, so to workaround this, we actually need to
+               generate an empty jar -->
+          <skipIfEmpty>false</skipIfEmpty>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>


### PR DESCRIPTION
It might be something new I haven't learned about maven, but it seems like just a type in the POM: you can't consume java classes from a binary .pom right?

Another thing not addressed here, but something we should think about is, do we want jcommon-all to contain all classes from all jcommon artifacts in one jar, or do we want it to contain that plus all dependencies of those too? Right now it contains all jcommon classes and all dependencies.
