### PR TITLE
[stats] fix ArithmeticDecoder zero-padding

### DIFF
--- a/stats/src/main/java/com/facebook/stats/cardinality/ArithmeticDecoder.java
+++ b/stats/src/main/java/com/facebook/stats/cardinality/ArithmeticDecoder.java
@@ -28,7 +28,6 @@ class ArithmeticDecoder {
   private long low;
   private long high;
   private long value;
-  private int bufferedBytes;
 
   private final InputStream in;
 
@@ -43,7 +42,6 @@ class ArithmeticDecoder {
     // We initialize the decoder with 48 bits (6 bytes) of input.
     for (int i = 0; i < 6; ++i) {
       bufferByte();
-      ++bufferedBytes;
     }
   }
 
@@ -98,11 +96,8 @@ class ArithmeticDecoder {
     // read a byte and add to the value
     int nextByte = in.read();
     if (nextByte < 0) {
-      if (bufferedBytes == 0) {
-        return;
-      }
+      // pad with zeros
       value <<= 8;
-      --bufferedBytes;
     } else {
       value = (value << 8);
       value |= nextByte;

--- a/stats/src/test/java/com/facebook/stats/cardinality/TestArithmeticCodec.java
+++ b/stats/src/test/java/com/facebook/stats/cardinality/TestArithmeticCodec.java
@@ -69,6 +69,27 @@ public class TestArithmeticCodec {
   }
 
   @Test
+  public void testDecodeZeroPaddingRequired() throws Exception {
+    // ArithmeticDecoder buffers 6 bytes; when there are fewer than 6, it should treat the input as
+    // if it had zeros for the missing bytes.  In practice, this rarely matters, but for the case
+    // below, getting it wrong results in an "IllegalArgumentException: targetCount is negative" due
+    // to ArithmeticDecoder.bufferByte() removing underflow bytes from high and low, but not value.
+    int[] buckets = new int[2048];
+
+    buckets[860] = 1;
+    buckets[1258] = 1;
+    buckets[1618] = 1;
+    buckets[2033] = 1;
+
+    testRoundTrip(
+        HyperLogLogCodec.createHyperLogLogSymbolModel(4, 2048, (byte) 1),
+        2,
+        Ints.asList(buckets),
+        2048
+    );
+  }
+
+  @Test
   public void testRoundTrip() throws Exception {
     testRoundTrip(new SortedStaticDataModelFactory(new ExponentiallyDecreasingHistogramFactory()));
     testRoundTrip(new SortedStaticDataModelFactory(new GaussianHistogramFactory()));


### PR DESCRIPTION
Fix edge case in some cases where encoded input has fewer than 6 bytes and we get unlucky with underflow.  See comments in TestArithmeticCodec.testDecodeZeroPaddingRequired() for more details.
