### PR TITLE
Try to use System.nanotime instead of System.currentTimeMills for measuring time in stats

### DIFF
--- a/stats/src/main/java/com/facebook/stats/AbstractCompositeCounter.java
+++ b/stats/src/main/java/com/facebook/stats/AbstractCompositeCounter.java
@@ -70,7 +70,7 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
     this.maxLength = maxLength;
     this.maxChunkLength = maxChunkLength;
 
-    DateTime now = new DateTime();
+    DateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
 
     start = now;
     end = now;
@@ -106,7 +106,7 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
    */
   @Override
   public void add(long delta) {
-    DateTime now = new DateTime();
+    DateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
     C last;
 
     synchronized (this) {
@@ -245,7 +245,7 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
    * view of the current set of counters.
    */
   protected synchronized void trimIfNeeded() {
-    Duration delta = new Duration(start, new DateTime())
+    Duration delta = new Duration(start, new DateTime(DateTimeUtils.currentTimeMillis()))
       .minus(maxLength);
 
     if (delta.isLongerThan(Duration.ZERO)) {

--- a/stats/src/main/java/com/facebook/stats/CompositeGaugeCounter.java
+++ b/stats/src/main/java/com/facebook/stats/CompositeGaugeCounter.java
@@ -63,7 +63,7 @@ public class CompositeGaugeCounter extends AbstractCompositeSum<GaugeCounter>
    */
   @Override
   public void add(long delta, long nsamples) {
-    DateTime now = new DateTime();
+    DateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
     GaugeCounter last;
 
     synchronized (this) {

--- a/stats/src/main/java/com/facebook/stats/CompositeMax.java
+++ b/stats/src/main/java/com/facebook/stats/CompositeMax.java
@@ -19,7 +19,6 @@ import org.joda.time.ReadableDateTime;
 import org.joda.time.ReadableDuration;
 
 import java.util.Arrays;
-import java.util.Iterator;
 
 public class CompositeMax extends AbstractCompositeCounter<EventCounter>
   implements EventCounter {

--- a/stats/src/main/java/com/facebook/stats/DateTimeUtils.java
+++ b/stats/src/main/java/com/facebook/stats/DateTimeUtils.java
@@ -1,0 +1,25 @@
+package com.facebook.stats;
+
+/**
+ * A drop-in replacement for the joda time DateTimeUtils but uses System.nanoTime
+ * under the hood. This is intended to be a bridge for the legacy code written
+ * against DateTimeUtils.currentTimeMills().
+ */
+public class DateTimeUtils {
+
+  private static boolean isFixed = false;
+  private static long fixedValue;
+
+  public static void setCurrentMillisFixed(long value) {
+    isFixed = true;
+    fixedValue = value;
+  }
+
+  public static long currentTimeMillis() {
+    return isFixed ? fixedValue : System.nanoTime() / 1000000;
+  }
+
+  public static void setCurrentMillisSystem() {
+    isFixed = false;
+  }
+}

--- a/stats/src/main/java/com/facebook/stats/DecayCounter.java
+++ b/stats/src/main/java/com/facebook/stats/DecayCounter.java
@@ -129,7 +129,7 @@ public class DecayCounter implements EventCounter {
   }
 
   DateTime getNow() {
-    return new DateTime();
+    return new DateTime(DateTimeUtils.currentTimeMillis());
   }
 }
 

--- a/stats/src/main/java/com/facebook/stats/EventRateImpl.java
+++ b/stats/src/main/java/com/facebook/stats/EventRateImpl.java
@@ -33,7 +33,7 @@ public class EventRateImpl implements EventRate {
   }
 
   public EventRateImpl(EventCounterIf<EventCounter> counter, Duration windowSize) {
-    this(counter, windowSize, new DateTime());
+    this(counter, windowSize, new DateTime(DateTimeUtils.currentTimeMillis()));
   }
 
   @Override
@@ -54,7 +54,7 @@ public class EventRateImpl implements EventRate {
 
   private Duration getPeriodSize() {
     // normalize by the time since server start
-    ReadableDateTime now = new DateTime();
+    ReadableDateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
     Duration periodSize = new Duration(start, now);
 
     if (periodSize.isLongerThan(windowSize)) {

--- a/stats/src/main/java/com/facebook/stats/MultiWindowGauge.java
+++ b/stats/src/main/java/com/facebook/stats/MultiWindowGauge.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDateTime;
 
@@ -44,7 +43,7 @@ public class MultiWindowGauge implements ReadableMultiWindowGauge, WritableMulti
       newCompositeGaugeCounter(60, gaugeCounterFactory),
       newCompositeGaugeCounter(10, gaugeCounterFactory),
       newCompositeGaugeCounter(1, gaugeCounterFactory),
-      new DateTime()
+      new DateTime(DateTimeUtils.currentTimeMillis())
     );
   }
 
@@ -97,7 +96,7 @@ public class MultiWindowGauge implements ReadableMultiWindowGauge, WritableMulti
     long value = counter.getValue();
     ReadableDateTime end = counter.getEnd();
     ReadableDateTime start = counter.getStart();
-    ReadableDateTime now = new DateTime();
+    ReadableDateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
     Duration duration = now.isBefore(end) ?
       new Duration(start, now) :    // so far
       new Duration(start, end);
@@ -194,7 +193,7 @@ public class MultiWindowGauge implements ReadableMultiWindowGauge, WritableMulti
 
   @Override
   public long getAllTimeRate() {
-    Duration sinceStart = new Duration(start, new DateTime());
+    Duration sinceStart = new Duration(start, new DateTime(DateTimeUtils.currentTimeMillis()));
     if (sinceStart.getStandardSeconds() == 0) {
       return 0;
     }
@@ -206,7 +205,7 @@ public class MultiWindowGauge implements ReadableMultiWindowGauge, WritableMulti
    * composite counters.
    */
   private GaugeCounter nextCurrentCounter() {
-    ReadableDateTime now = new DateTime();
+    ReadableDateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
     GaugeCounter gaugeCounter = gaugeCounterFactory.create(
       now, now.toDateTime().plusSeconds(6)
     );

--- a/stats/src/main/java/com/facebook/stats/MultiWindowMax.java
+++ b/stats/src/main/java/com/facebook/stats/MultiWindowMax.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDateTime;
 import org.joda.time.ReadableDuration;
@@ -99,7 +98,7 @@ public class MultiWindowMax implements ReadableMultiWindowCounter, WritableMulti
   }
 
   private MaxEventCounter addNewCurrentCounter() {
-    ReadableDateTime now = new DateTime();
+    ReadableDateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
 
     MaxEventCounter maxEventCounter = new MaxEventCounter(
       now,

--- a/stats/src/main/java/com/facebook/stats/MultiWindowMin.java
+++ b/stats/src/main/java/com/facebook/stats/MultiWindowMin.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDateTime;
 import org.joda.time.ReadableDuration;
@@ -99,7 +98,7 @@ public class MultiWindowMin implements ReadableMultiWindowCounter, WritableMulti
   }
 
   private MinEventCounter addNewCurrentCounter() {
-    ReadableDateTime now = new DateTime();
+    ReadableDateTime now = new DateTime(DateTimeUtils.currentTimeMillis());
 
     MinEventCounter minEventCounter = new MinEventCounter(
       now,

--- a/stats/src/main/java/com/facebook/stats/MultiWindowRate.java
+++ b/stats/src/main/java/com/facebook/stats/MultiWindowRate.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDateTime;
 
@@ -42,7 +41,7 @@ public class MultiWindowRate implements ReadableMultiWindowRate, WritableMultiWi
       newCompositeEventCounter(60),
       newCompositeEventCounter(10),
       newCompositeEventCounter(1),
-      new DateTime(),
+      new DateTime(DateTimeUtils.currentTimeMillis()),
       timeBucketSizeMillis
     );
   }
@@ -163,7 +162,7 @@ public class MultiWindowRate implements ReadableMultiWindowRate, WritableMultiWi
   }
 
   protected ReadableDateTime getNow() {
-    return new DateTime();
+    return new DateTime(DateTimeUtils.currentTimeMillis());
   }
 
   // current

--- a/stats/src/main/java/com/facebook/stats/RealtimeClock.java
+++ b/stats/src/main/java/com/facebook/stats/RealtimeClock.java
@@ -18,6 +18,6 @@ package com.facebook.stats;
 class RealtimeClock implements Clock {
   @Override
   public long getMillis() {
-    return System.currentTimeMillis();
+    return System.nanoTime() / 1000000;
   }
 }

--- a/stats/src/main/java/com/facebook/stats/ShardedConcurrentCounter.java
+++ b/stats/src/main/java/com/facebook/stats/ShardedConcurrentCounter.java
@@ -15,8 +15,6 @@
  */
 package com.facebook.stats;
 
-import org.joda.time.DateTimeUtils;
-
 import java.util.concurrent.atomic.AtomicLong;
 
 public class ShardedConcurrentCounter {

--- a/stats/src/test/java/com/facebook/stats/TestCompositeMax.java
+++ b/stats/src/test/java/com/facebook/stats/TestCompositeMax.java
@@ -15,9 +15,7 @@
  */
 package com.facebook.stats;
 
-import com.facebook.util.TimeUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.testng.Assert;

--- a/stats/src/test/java/com/facebook/stats/TestCompositeMin.java
+++ b/stats/src/test/java/com/facebook/stats/TestCompositeMin.java
@@ -15,9 +15,7 @@
  */
 package com.facebook.stats;
 
-import com.facebook.util.TimeUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 import org.testng.Assert;

--- a/stats/src/test/java/com/facebook/stats/TestCompositeSum.java
+++ b/stats/src/test/java/com/facebook/stats/TestCompositeSum.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDateTime;
 import org.joda.time.ReadableDuration;

--- a/stats/src/test/java/com/facebook/stats/TestEventRate.java
+++ b/stats/src/test/java/com/facebook/stats/TestEventRate.java
@@ -16,7 +16,6 @@
 package com.facebook.stats;
 
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;

--- a/stats/src/test/java/com/facebook/stats/TestMultiWindowMax.java
+++ b/stats/src/test/java/com/facebook/stats/TestMultiWindowMax.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.stats;
 
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/stats/src/test/java/com/facebook/stats/TestMultiWindowMin.java
+++ b/stats/src/test/java/com/facebook/stats/TestMultiWindowMin.java
@@ -15,7 +15,6 @@
  */
 package com.facebook.stats;
 
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/stats/src/test/java/com/facebook/stats/TestMultiWindowRate.java
+++ b/stats/src/test/java/com/facebook/stats/TestMultiWindowRate.java
@@ -17,7 +17,6 @@ package com.facebook.stats;
 
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/stats/src/test/java/com/facebook/stats/TimeUtil.java
+++ b/stats/src/test/java/com/facebook/stats/TimeUtil.java
@@ -1,0 +1,24 @@
+package com.facebook.stats;
+
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+/**
+ */
+public class TimeUtil {
+  /**
+   * these methods affect only code that relies on DateTimeUtils.currentTimeMillis()
+   *
+   * NOTE: manipulation of {@link DateTimeUtils.currentTimeMillis()} is not thread safe
+   * to begin with, so neither is this
+   */
+  public static void setNow(DateTime now) {
+    DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+  }
+
+  public static void advanceNow(Duration duration) {
+    long now = DateTimeUtils.currentTimeMillis();
+
+    DateTimeUtils.setCurrentMillisFixed(now + duration.getMillis());
+  }
+}

--- a/stats/src/test/java/com/facebook/stats/mx/TestStatsUtil.java
+++ b/stats/src/test/java/com/facebook/stats/mx/TestStatsUtil.java
@@ -15,11 +15,11 @@
  */
 package com.facebook.stats.mx;
 
+import com.facebook.stats.DateTimeUtils;
 import com.facebook.stats.MultiWindowDistribution;
 import com.facebook.stats.QuantileDigest;
-import com.facebook.util.TimeUtil;
+import com.facebook.stats.TimeUtil;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;


### PR DESCRIPTION
System.currentTimeMillis calls gettimeofday() in Linux. System.nanoTime() calls clock_gettime(). According to http://stackoverflow.com/questions/12392278/measure-time-in-linux-getrusage-vs-clock-gettime-vs-clock-vs-gettimeofday, gettimeofday() is hardly the right choice for measuring passage of time since it is wall clock time and is subject to a lot of external factors (leap seconds, ntpd resets, daylight savings).

This pull request tried to build a bridge class DateTimeUtils that uses System.nanoTime() under the hood. Since the code currently uses joda time extensively, refactoring all of it is worth doing only if people showed interest in this pull request. Suggestions on how to make this patch cleaner is greatly appreciated.