### PR TITLE
update oss pom dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ limitations under the License.
   <parent>
     <groupId>com.facebook</groupId>
     <artifactId>facebook-oss-pom</artifactId>
-    <version>5</version>
+    <version>6</version>
   </parent>
 
   <groupId>com.facebook.jcommon</groupId>


### PR DESCRIPTION
version 5 does not work well with maven 3.1.0, since the plugin versions it refers to are known to have compatibility problems
