### PR TITLE
Add OptionImpl convenience constructor

### DIFF
--- a/config/src/main/java/com/facebook/config/dynamic/OptionImpl.java
+++ b/config/src/main/java/com/facebook/config/dynamic/OptionImpl.java
@@ -27,6 +27,13 @@ public class OptionImpl<V> implements Option<V> {
 
   private volatile V value;
 
+  public OptionImpl() {
+  }
+
+  public OptionImpl(V value) {
+    this.value = value;
+  }
+
   @Override
   public V getValue() {
     return value;

--- a/config/src/test/java/com/facebook/config/dynamic/TestOptionImpl.java
+++ b/config/src/test/java/com/facebook/config/dynamic/TestOptionImpl.java
@@ -26,7 +26,7 @@ public class TestOptionImpl {
 
   @BeforeMethod(alwaysRun = true)
   protected void setUp() throws Exception {
-    option = new OptionImpl<String>();
+    option = new OptionImpl<>();
   }
 
   @Test(groups = "fast")
@@ -87,6 +87,11 @@ public class TestOptionImpl {
     watcher1.assertState("test", 1);
     watcher2.assertState("test", 1);
     Assert.assertEquals(failureCount.get(), 1);
+  }
+
+  @Test(groups = "fast")
+  public void testInitialValue() throws Exception {
+    Assert.assertEquals(new OptionImpl<>("test").getValue(), "test");
   }
 
   private static class Watcher implements OptionWatcher<String> {


### PR DESCRIPTION
For cases where a hard-coded value of OptionImpl is used (e.g., unit tests), having to create the option and then set it's value is annoying. Add a constructor for creating an OptionImp with an initial value to make this simpler.
