### PR TITLE
Add way to get dynamic counters directly from the stats object

### DIFF
--- a/stats/src/main/java/com/facebook/stats/mx/Stats.java
+++ b/stats/src/main/java/com/facebook/stats/mx/Stats.java
@@ -343,6 +343,16 @@ public class Stats implements StatsReader, StatsCollector {
     return internalGetAttribute(key);
   }
 
+  @Override
+  public Callable<Long> getDynamicCounter(StatType key) {
+    return dynamicCounters.get(key.getKey());
+  }
+
+  @Override
+  public Callable<Long> getDynamicCounter(String key) {
+    return dynamicCounters.get(key);
+  }
+
   private String internalGetAttribute(String key) {
     try {
       Callable<String> callable = attributes.get(key);

--- a/stats/src/main/java/com/facebook/stats/mx/StatsReader.java
+++ b/stats/src/main/java/com/facebook/stats/mx/StatsReader.java
@@ -15,12 +15,12 @@
  */
 package com.facebook.stats.mx;
 
-
 import com.facebook.stats.MultiWindowDistribution;
 import com.facebook.stats.MultiWindowRate;
 import com.facebook.stats.MultiWindowSpread;
 
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 public interface StatsReader {
   public void exportCounters(Map<String, Long> counters);
@@ -36,6 +36,8 @@ public interface StatsReader {
   public MultiWindowDistribution getDistribution(String key);
   public String getAttribute(StatType key);
   public String getAttribute(String key);
+  public Callable<Long> getDynamicCounter(StatType key);
+  public Callable<Long> getDynamicCounter(String key);
 
   /**
    * @return returns a snapshot copy of the attributes

--- a/stats/src/test/java/com/facebook/stats/mx/TestStats.java
+++ b/stats/src/test/java/com/facebook/stats/mx/TestStats.java
@@ -16,7 +16,6 @@
 package com.facebook.stats.mx;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.math3.analysis.function.Add;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -58,8 +57,8 @@ public class TestStats {
     stats.setAttribute(KEY1, KEY2);
 
     // Test out that the stats attributemap is as expected
-    Map <String, String> statsAttributes = stats.getAttributes();
-    Assert.assertEquals(attributeMap, statsAttributes);    
+    Map<String, String> statsAttributes = stats.getAttributes();
+    Assert.assertEquals(attributeMap, statsAttributes);
   }
 
   /**
@@ -67,7 +66,7 @@ public class TestStats {
    */
   @Test(groups = "fast")
   public void testAttributeString() {
-    for (Map.Entry<String, String> attribute: attributeMap.entrySet()) {
+    for (Map.Entry<String, String> attribute : attributeMap.entrySet()) {
       stats.setAttribute(attribute.getKey(), attribute.getValue());
     }
     verifyStatAttributes();
@@ -82,7 +81,7 @@ public class TestStats {
       stats.setAttribute(key, 
         new Callable<String>() {
           @Override
-          public String call() throws Exception {          
+          public String call() throws Exception {
             return TestStats.this.attributeMap.get(key);
           }
         });
@@ -122,28 +121,37 @@ public class TestStats {
     final Map<String, Long> exported = new HashMap<>();
     stats.exportCounters(exported);
     Assert.assertEquals(exported.get(name), Long.valueOf(1));
-    
+
     // Test that the value gets exported
     longValue.setValue(123);
     exported.clear();
     stats.exportCounters(exported);
     Assert.assertEquals(exported.get(name), Long.valueOf(123));
-    
+
     // Test that a duplicate set fails to override the previous value
     LongWrapper duplicateValue = new LongWrapper(24);
     Assert.assertFalse(stats.addDynamicCounter(name, duplicateValue));
     exported.clear();
     stats.exportCounters(exported);
     Assert.assertEquals(exported.get(name), Long.valueOf(123));
-    
+
     // Test unset
     Assert.assertTrue(stats.removeDynamicCounter(name));
     exported.clear();
     stats.exportCounters(exported);
     Assert.assertFalse(exported.containsKey(name));
-    
+
     // Test unset for non-existent key
     Assert.assertFalse(stats.removeDynamicCounter(name));
+  }
+
+  @Test(groups = "fast")
+  public void testGetDynamicCounters() throws Exception {
+    LongWrapper longValue = new LongWrapper(1);
+    final String name = "testCounter";
+    Assert.assertTrue(stats.addDynamicCounter(name, longValue));
+    Callable<Long> dynamicCounter = stats.getDynamicCounter(name);
+    Assert.assertEquals(dynamicCounter.call().longValue(), 1);
   }
 
   @Test(groups = "fast")
@@ -185,6 +193,7 @@ public class TestStats {
     }
 
     private long value;
+
     @Override
     public Long call() throws Exception {
       return value;


### PR DESCRIPTION
It's sometimes useful to be able to get dynamic counters without
constructing the entire stats map. Add a way to ask the Stats
object for the counter directly.

Test Plan: Add a unit test