### PR TITLE
SubprocessImpl to remove shutdown hooks on kill

### DIFF
--- a/tools/src/main/java/com/facebook/tools/subprocess/SubprocessBuilder.java
+++ b/tools/src/main/java/com/facebook/tools/subprocess/SubprocessBuilder.java
@@ -18,9 +18,6 @@ package com.facebook.tools.subprocess;
 import com.facebook.tools.io.IO;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -172,25 +169,6 @@ public class SubprocessBuilder {
         );
       }
 
-      Runtime.getRuntime().addShutdownHook(
-        new Thread(
-          new Runnable() {
-            @Override
-            public void run() {
-              //noinspection EmptyTryBlock,UnusedDeclaration
-              try (
-                InputStream inputStream = process.getInputStream();
-                OutputStream outputStream = process.getOutputStream();
-                InputStream errorStream = process.getErrorStream()
-              ) {
-              } catch (IOException | RuntimeException ignored) {
-              }
-
-              process.destroy();
-            }
-          }
-        )
-      );
 
       if (echoCommand != null) {
         Iterator<String> iterator = command.iterator();

--- a/tools/src/main/java/com/facebook/tools/subprocess/SubprocessImpl.java
+++ b/tools/src/main/java/com/facebook/tools/subprocess/SubprocessImpl.java
@@ -50,6 +50,7 @@ class SubprocessImpl implements Subprocess {
   private final Future<?> stdoutFuture;
   private final Future<?> stderrFuture;
   private final AtomicBoolean consumedStdout = new AtomicBoolean(false);
+  private final Thread shutdownHook;
 
   SubprocessImpl(
     List<String> command, Process process, IO echo, int outputBytesLimit, boolean streaming
@@ -86,6 +87,23 @@ class SubprocessImpl implements Subprocess {
       Executors.newCachedThreadPool(new NamedDaemonThreadFactory(name + "-stderr"));
     stdoutFuture = stdoutExecutorService.submit(stdout);
     stderrFuture = stderrExecutorService.submit(stderr);
+
+    shutdownHook = new Thread(
+      () -> {
+        //noinspection EmptyTryBlock,UnusedDeclaration
+        try (
+          InputStream inputStream = process.getInputStream();
+          OutputStream outputStream = process.getOutputStream();
+          InputStream errorStream = process.getErrorStream()
+        ) {
+        } catch (IOException | RuntimeException ignored) {
+        }
+
+        process.destroy();
+      }
+    );
+
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
   }
 
 
@@ -164,6 +182,7 @@ class SubprocessImpl implements Subprocess {
     stderrFuture.cancel(true);
     stdoutExecutorService.shutdownNow();
     stderrExecutorService.shutdownNow();
+    Runtime.getRuntime().removeShutdownHook(shutdownHook);
   }
 
   @Override


### PR DESCRIPTION
Unless the shutdown hook is removed it will remain there forever, causing a memory leak.