### PR TITLE
Optimize SparseEstimator(int[] buckets) constructor

### DIFF
--- a/stats/src/main/java/com/facebook/stats/cardinality/SparseEstimator.java
+++ b/stats/src/main/java/com/facebook/stats/cardinality/SparseEstimator.java
@@ -50,19 +50,24 @@ class SparseEstimator
   */
   private long[] slots;
 
-  public SparseEstimator(int numberOfBuckets) {
+  SparseEstimator(int numberOfBuckets) {
     this(numberOfBuckets, 1);
   }
 
-  public SparseEstimator(int[] buckets) {
+  SparseEstimator(int[] buckets) {
     this(buckets.length, countNonZeroBuckets(buckets));
 
-    for (int i = 0; i < buckets.length; i++) {
-      setIfGreater(i, buckets[i]);
+    for (int bucket = 0; bucket < buckets.length; bucket++) {
+      int value = buckets[bucket];
+
+      if (value != 0) {
+        setEntry(bucketCount, bucket, value);
+        ++bucketCount;
+      }
     }
   }
 
-  public SparseEstimator(int numberOfBuckets, int initialCapacity) {
+  SparseEstimator(int numberOfBuckets, int initialCapacity) {
     Preconditions.checkArgument(
       Numbers.isPowerOf2(numberOfBuckets),
       "numberOfBuckets must be a power of 2"
@@ -89,7 +94,9 @@ class SparseEstimator
     if (index < 0) {
       insertAt(-(index + 1), bucket, highestBitPosition);
       return true;
-    } else if (getEntry(index).getValue() < highestBitPosition) {
+    }
+
+    if (getEntry(index).getValue() < highestBitPosition) {
       setEntry(index, bucket, highestBitPosition);
       return true;
     }
@@ -246,7 +253,7 @@ class SparseEstimator
 
   private static int countNonZeroBuckets(int[] buckets) {
     int count = 0;
-    for (Integer bucket : buckets) {
+    for (int bucket : buckets) {
       if (bucket > 0) {
         ++count;
       }

--- a/stats/src/test/java/com/facebook/stats/cardinality/TestSparseEstimator.java
+++ b/stats/src/test/java/com/facebook/stats/cardinality/TestSparseEstimator.java
@@ -15,7 +15,10 @@
  */
 package com.facebook.stats.cardinality;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 import static org.testng.Assert.assertEquals;
 
@@ -36,5 +39,28 @@ public class TestSparseEstimator
 
     SparseEstimator other = new SparseEstimator(estimator.buckets());
     assertEquals(estimator.buckets(), other.buckets());
+  }
+
+  @Test
+  public void testBucketsConstructor() {
+    int[] buckets = new int[1024];
+
+    for (int bucket = 0; bucket < buckets.length; ++bucket) {
+      for (int maxBit = 0; maxBit < 16; ++maxBit) {
+        buckets[bucket] = maxBit;
+
+        SparseEstimator actual = new SparseEstimator(buckets);
+        SparseEstimator expected = new SparseEstimator(buckets.length);
+
+        for (int x = 0; x < buckets.length; ++x) {
+          expected.setIfGreater(x, buckets[x]);
+        }
+
+        // Assert.assertEquals() is much slower -- using it doubles the test time!
+        if (!Arrays.equals(actual.buckets(), expected.buckets())) {
+          Assert.fail(bucket + " " + maxBit);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Convert from doing O(nlgn) operations to O(n). This can save minutes of CPU time in code that does millions of SparseEstimator creations.