### PR TITLE
foo.count.60, etc. counters should count number of samples.

### DIFF
--- a/stats/src/main/java/com/facebook/stats/StatsManager.java
+++ b/stats/src/main/java/com/facebook/stats/StatsManager.java
@@ -184,7 +184,7 @@ public class StatsManager implements HistoryManager {
           return counterMap.get(shortName).getMinuteRate();
         }
         if (ending2.equals(".count.60")) {
-          return counterMap.get(shortName).getMinuteSum();
+          return counterMap.get(shortName).getMinuteSamples();
         }
       }
 
@@ -199,7 +199,7 @@ public class StatsManager implements HistoryManager {
           return counterMap.get(shortName).getTenMinuteRate();
         }
         if (ending2.equals(".count.600")) {
-          return counterMap.get(shortName).getTenMinuteSum();
+          return counterMap.get(shortName).getTenMinuteSamples();
         }
       }
 
@@ -214,7 +214,7 @@ public class StatsManager implements HistoryManager {
           return counterMap.get(shortName).getHourRate();
         }
         if (ending2.equals(".count.3600")) {
-          return counterMap.get(shortName).getHourSum();
+          return counterMap.get(shortName).getHourSamples();
         }
       }
 
@@ -228,7 +228,7 @@ public class StatsManager implements HistoryManager {
         return counterMap.get(shortName).getAllTimeRate();
       }
       if (fullName.endsWith(".count")) {
-        return counterMap.get(shortName).getAllTimeSum();
+        return counterMap.get(shortName).getAllTimeSamples();
       }
     } catch (Exception e) {
       throw new IllegalArgumentException("Stat name '" + shortName

--- a/stats/src/test/java/com/facebook/stats/TestStatsManager.java
+++ b/stats/src/test/java/com/facebook/stats/TestStatsManager.java
@@ -43,21 +43,21 @@ public class TestStatsManager {
     }
     System.out.println(toString(stats));
 
-    Assert.assertEquals(amt, stats.getCounter("basic.avg"));
-    Assert.assertEquals(amt, stats.getCounter("basic.avg.60"));
-    Assert.assertEquals(amt, stats.getCounter("basic.avg.600"));
-    Assert.assertEquals(amt, stats.getCounter("basic.avg.3600"));
+    Assert.assertEquals(stats.getCounter("basic.avg"), amt);
+    Assert.assertEquals(stats.getCounter("basic.avg.60"), amt);
+    Assert.assertEquals(stats.getCounter("basic.avg.600"), amt);
+    Assert.assertEquals(stats.getCounter("basic.avg.3600"), amt);
 
     stats.addStatExportType("test-sum", HistoryManager.ExportType.SUM);
     for (int i=0; i<num; i++) {
-      stats.addStatValue("test-sum", 1);
+      stats.addStatValue("test-sum", amt);
     }
     System.out.println(toString(stats));
 
-    Assert.assertEquals(num, stats.getCounter("test-sum.sum"));
-    Assert.assertEquals(num, stats.getCounter("test-sum.sum.60"));
-    Assert.assertEquals(num, stats.getCounter("test-sum.sum.600"));
-    Assert.assertEquals(num, stats.getCounter("test-sum.sum.3600"));
+    Assert.assertEquals(stats.getCounter("test-sum.sum"), num*amt);
+    Assert.assertEquals(stats.getCounter("test-sum.sum.60"), num*amt);
+    Assert.assertEquals(stats.getCounter("test-sum.sum.600"), num*amt);
+    Assert.assertEquals(stats.getCounter("test-sum.sum.3600"), num*amt);
 
     stats.addStatExportType("test-rate", HistoryManager.ExportType.RATE);
     stats.addStatExportType("test-avg", HistoryManager.ExportType.AVG);
@@ -67,20 +67,30 @@ public class TestStatsManager {
       stats.addStatValue("test-avg", amt);
       stats.addStatValue("test-count", amt);
     }
-    Assert.assertEquals(amt*num, stats.getCounter("test-count.count"));
+
+    System.out.println(toString(stats));
+    Assert.assertEquals(stats.getCounter("test-count.count"), num);
+    Assert.assertEquals(stats.getCounter("test-count.count.60"), num);
+    Assert.assertEquals(stats.getCounter("test-count.count.600"), num);
+    Assert.assertEquals(stats.getCounter("test-count.count.3600"), num);
+
+    Assert.assertEquals(stats.getCounter("test-count.avg"), amt);
+    Assert.assertEquals(stats.getCounter("test-count.avg.60"), amt);
+    Assert.assertEquals(stats.getCounter("test-count.avg.600"), amt);
+    Assert.assertEquals(stats.getCounter("test-count.avg.3600"), amt);
 
     stats.addStatExportType("test-all", HistoryManager.ExportType.SUM);
     stats.addStatExportType("test-all", HistoryManager.ExportType.RATE);
     stats.addStatExportType("test-all", HistoryManager.ExportType.AVG);
     stats.addStatExportType("test-all", HistoryManager.ExportType.COUNT);
 
+
+    stats.addStatValue("test-all", amt);
+    stats.addStatValue("test-all", amt);
+
     System.out.println(toString(stats));
-
-    stats.addStatValue("test-all", amt);
-    stats.addStatValue("test-all", amt);
-
-    Assert.assertEquals(amt+amt, stats.getCounter("test-all.sum"));
-    Assert.assertEquals(amt, stats.getCounter("test-all.avg"));
-    Assert.assertEquals(amt+amt, stats.getCounter("test-all.count"));
+    Assert.assertEquals(stats.getCounter("test-all.sum"), amt+amt);
+    Assert.assertEquals(stats.getCounter("test-all.avg"), amt);
+    Assert.assertEquals(stats.getCounter("test-all.count"), 2);
   }
 }


### PR DESCRIPTION
The foo.count.60, foo.count.600, etc. counters should count the number
of samples, not the sum of the values. This PR fixes that.
Also, reordering the arguments in unit test so that "actual,expected" are properly ordered.