### PR TITLE
Fix getTimeIntervalStart() handling of daylight saving gaps

### DIFF
--- a/util/src/main/java/com/facebook/util/TimeIntervalType.java
+++ b/util/src/main/java/com/facebook/util/TimeIntervalType.java
@@ -25,14 +25,24 @@ import org.joda.time.PeriodType;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.field.FieldUtils;
 
+import static org.joda.time.DateTimeFieldType.centuryOfEra;
+import static org.joda.time.DateTimeFieldType.dayOfMonth;
+import static org.joda.time.DateTimeFieldType.hourOfDay;
+import static org.joda.time.DateTimeFieldType.millisOfSecond;
+import static org.joda.time.DateTimeFieldType.minuteOfHour;
+import static org.joda.time.DateTimeFieldType.monthOfYear;
+import static org.joda.time.DateTimeFieldType.secondOfMinute;
+import static org.joda.time.DateTimeFieldType.weekOfWeekyear;
+import static org.joda.time.DateTimeFieldType.yearOfCentury;
+
 /**
  * Represents a time interval type when specifying a time period. Instances of
  * this class provide means to calculate the start instant of the interval
  * containing a given time instant.
- * 
+ *
  * <p>
- * Each interval type computes the time interval assuming that they start 
- * from it's minimum value. For example, MINUTE represents the time interval 
+ * Each interval type computes the time interval assuming that they start
+ * from it's minimum value. For example, MINUTE represents the time interval
  * starting from the 0th minute in the containing hour. So given a time instant
  * 2011-10-09T13:11:49, and a time interval type of MINUTE and length 3, the
  * start instant of the time interval containing that instant will be
@@ -40,31 +50,31 @@ import org.joda.time.field.FieldUtils;
  * </p>
  */
 public enum TimeIntervalType {
-  MILLIS(PeriodType.millis(), DateTimeFieldType.millisOfSecond(), null) {
+  MILLIS(PeriodType.millis(), millisOfSecond(), secondOfMinute()) {
     @Override
     public Period toPeriod(int length) {
       return Period.millis(length);
     }
   },
-  SECOND(PeriodType.seconds(), DateTimeFieldType.secondOfMinute(), MILLIS) {
+  SECOND(PeriodType.seconds(), secondOfMinute(), minuteOfHour()) {
     @Override
     public Period toPeriod(int length) {
       return Period.seconds(length);
     }
   },
-  MINUTE(PeriodType.minutes(), DateTimeFieldType.minuteOfHour(), SECOND) {
+  MINUTE(PeriodType.minutes(), minuteOfHour(), hourOfDay()) {
     @Override
     public Period toPeriod(int length) {
       return Period.minutes(length);
     }
   },
-  HOUR(PeriodType.hours(), DateTimeFieldType.hourOfDay(), MINUTE) {
+  HOUR(PeriodType.hours(), hourOfDay(), dayOfMonth()) {
     @Override
     public Period toPeriod(int length) {
       return Period.hours(length);
     }
   },
-  DAY(PeriodType.days(), DateTimeFieldType.dayOfMonth(), HOUR) {
+  DAY(PeriodType.days(), dayOfMonth(), monthOfYear()) {
     @Override
     public Period toPeriod(int length) {
       return Period.days(length);
@@ -76,19 +86,19 @@ public enum TimeIntervalType {
    * as a time interval type, until we can have the weeks starting on the
    * correct day (Sunday/Monday) per the locale.
    */
-  WEEK(PeriodType.weeks(), DateTimeFieldType.weekOfWeekyear(), DAY) {
+  WEEK(PeriodType.weeks(), weekOfWeekyear(), yearOfCentury()) {
     @Override
     public Period toPeriod(int length) {
       return Period.weeks(length);
     }
   },
-  MONTH(PeriodType.months(), DateTimeFieldType.monthOfYear(), DAY) {
+  MONTH(PeriodType.months(), monthOfYear(), yearOfCentury()) {
     @Override
     public Period toPeriod(int length) {
       return Period.months(length);
     }
   },
-  YEAR(PeriodType.years(), DateTimeFieldType.yearOfCentury(), MONTH) {
+  YEAR(PeriodType.years(), yearOfCentury(), centuryOfEra()) {
     @Override
     public Period toPeriod(int length) {
       return Period.years(length);
@@ -97,36 +107,28 @@ public enum TimeIntervalType {
 
   private final PeriodType periodType;
   private final DateTimeFieldType fieldType;
-  private final TimeIntervalType subType;
+  private final DateTimeFieldType truncateFieldType;
 
-  /**
-   * Creates an instance.
-   * 
-   * @param type The field type corresponding to this interval type.
-   * @param subType The subtype for this type.
-   */
-  private TimeIntervalType(
-    PeriodType periodType,
-    DateTimeFieldType type,
-    TimeIntervalType subType
+  TimeIntervalType(
+    PeriodType periodType, DateTimeFieldType fieldType, DateTimeFieldType truncateFieldType
   ) {
     this.periodType = periodType;
-    this.fieldType = type;
-    this.subType = subType;
+    this.fieldType = fieldType;
+    this.truncateFieldType = truncateFieldType;
   }
 
   /**
    * Returns a period representing this interval type.
-   * 
+   *
    * @param length the multiple of the base period unit
    * @return the period value
    */
   public abstract Period toPeriod(int length);
 
   /**
-   * Validates that the specified interval value is valid for this 
+   * Validates that the specified interval value is valid for this
    * interval type in the supplied time zone.
-   * 
+   *
    * @param timeZone the time zone
    * @param intervalLength the interval length
    */
@@ -135,59 +137,45 @@ public enum TimeIntervalType {
     if (intervalLength < 1
       || intervalLength > field.getMaximumValue()) {
       throw new IllegalArgumentException(
-        "Supplied value " + intervalLength
-          + " is out of bounds for " + name()
+        "Supplied value " + intervalLength + " is out of bounds for " + name()
       );
     }
   }
 
 
   /**
-   * Gets the start instant given the event instant, interval length 
+   * Gets the start instant given the event instant, interval length
    * and the time zone for this interval type.
-   * 
+   *
    * @param instant the event time instant.
    * @param length the interval length
-   * 
-   * @return the start instant of the interval of given length that contains 
-   * the supplied time instant in the supplied time zone 
+   *
+   * @return the start instant of the interval of given length that contains
+   * the supplied time instant in the supplied time zone
    */
-  public DateTime getTimeIntervalStart(
-    DateTime instant,
-    long length
-  ) {
+  public DateTime getTimeIntervalStart(DateTime instant, long length) {
     validateValue(instant.getZone(), length);
-    // Get the time in the specified timezone
-    DateTime periodStart = instant;
-    // Clear all the fields for this intervalType and its subtypes
-    TimeIntervalType timeIntervalType = this;
-    while (timeIntervalType != null) {
-      periodStart = timeIntervalType.clearField(periodStart);
-      timeIntervalType = timeIntervalType.subType;
-    }
+
+    // Reset all the fields
+    DateTime periodStart = instant.property(truncateFieldType)
+      .roundFloorCopy();
     // figure out the which time interval does the instant lie in
     Period period = new Period(periodStart, instant, periodType);
     DurationField durationField = fieldType.getField(instant.getChronology()).getDurationField();
     int diff = period.get(durationField.getType());
     long startDelta = (diff / length) * length;
+
     return periodStart.withFieldAdded(durationField.getType(), FieldUtils.safeToInt(startDelta));
   }
 
   /**
    * Returns the number of milliseconds per unit of this interval type.
-   * 
+   *
    * @return the number of milliseconds per unit of this interval type.
    */
   public long toDurationMillis() {
     return fieldType.getDurationType().getField(
       // Assume that durations are always in UTC
       ISOChronology.getInstance(DateTimeZone.UTC)).getUnitMillis();
-  }
-
-  protected DateTime clearField(DateTime value) {
-    return value.withField(
-      fieldType,
-      fieldType.getField(value.getChronology()).getMinimumValue()
-    );
   }
 }

--- a/util/src/test/java/com/facebook/util/TestTimeIntervalType.java
+++ b/util/src/test/java/com/facebook/util/TestTimeIntervalType.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2016 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.facebook.util.TimeIntervalType.DAY;
+import static com.facebook.util.TimeIntervalType.HOUR;
+import static com.facebook.util.TimeIntervalType.MILLIS;
+import static com.facebook.util.TimeIntervalType.MINUTE;
+import static com.facebook.util.TimeIntervalType.MONTH;
+import static com.facebook.util.TimeIntervalType.SECOND;
+import static com.facebook.util.TimeIntervalType.WEEK;
+import static com.facebook.util.TimeIntervalType.YEAR;
+import static org.joda.time.DateTimeZone.UTC;
+
+/**
+ * Mostly conformance testing: these aren't testing how things <em>should</em> work but rather how
+ * they <em>do</em> work (since there's a lot of code that relies on the existing behavior).
+ */
+public class TestTimeIntervalType {
+  private static final DateTimeZone PDT = DateTimeZone.forID("America/Los_Angeles");
+
+  @Test
+  public void testMillisIntervalStart() throws Exception {
+    assertStart("2016-04-13T11:26:47.856-07:00", PDT, MILLIS, 1, "2016-04-13T11:26:47.856-07:00");
+    assertStart("2016-04-13T11:26:47.856-07:00", PDT, MILLIS, 100, "2016-04-13T11:26:47.800-07:00");
+    assertStart("2016-04-13T11:26:48.356-07:00", PDT, MILLIS, 1, "2016-04-13T11:26:48.356-07:00");
+    assertStart("2016-04-13T11:26:48.356-07:00", PDT, MILLIS, 100, "2016-04-13T11:26:48.300-07:00");
+  }
+
+  @Test
+  public void testSecondsIntervalStart() throws Exception {
+    assertStart("2016-04-13T11:25:51.302-07:00", PDT, SECOND, 1, "2016-04-13T11:25:51.000-07:00");
+    assertStart("2016-04-13T11:25:51.302-07:00", PDT, SECOND, 10, "2016-04-13T11:25:50.000-07:00");
+    assertStart("2016-04-13T11:25:51.302-07:00", PDT, SECOND, 30, "2016-04-13T11:25:30.000-07:00");
+    assertStart("2016-04-13T11:26:11.302-07:00", PDT, SECOND, 1, "2016-04-13T11:26:11.000-07:00");
+    assertStart("2016-04-13T11:26:11.302-07:00", PDT, SECOND, 10, "2016-04-13T11:26:10.000-07:00");
+    assertStart("2016-04-13T11:26:11.302-07:00", PDT, SECOND, 30, "2016-04-13T11:26:00.000-07:00");
+  }
+
+  @Test
+  public void testMinuteIntervalStart() throws Exception {
+    assertStart("2016-04-13T11:20:29.330-07:00", PDT, MINUTE, 1, "2016-04-13T11:20:00.000-07:00");
+    assertStart("2016-04-13T11:20:29.330-07:00", PDT, MINUTE, 5, "2016-04-13T11:20:00.000-07:00");
+    assertStart("2016-04-13T11:20:29.330-07:00", PDT, MINUTE, 15, "2016-04-13T11:15:00.000-07:00");
+    assertStart("2016-04-13T11:20:29.330-07:00", PDT, MINUTE, 30, "2016-04-13T11:00:00.000-07:00");
+    assertStart("2016-04-13T11:40:29.330-07:00", PDT, MINUTE, 1, "2016-04-13T11:40:00.000-07:00");
+    assertStart("2016-04-13T11:40:29.330-07:00", PDT, MINUTE, 5, "2016-04-13T11:40:00.000-07:00");
+    assertStart("2016-04-13T11:40:29.330-07:00", PDT, MINUTE, 15, "2016-04-13T11:30:00.000-07:00");
+    assertStart("2016-04-13T11:40:29.330-07:00", PDT, MINUTE, 30, "2016-04-13T11:30:00.000-07:00");
+  }
+
+  @Test
+  public void testDayIntervalStartUTC() throws Exception {
+    assertStart("2016-01-13T00:52:38.337Z", UTC, DAY, 1, "2016-01-13T00:00:00.000Z");
+    assertStart("2016-02-13T02:52:38.337Z", UTC, DAY, 2, "2016-02-13T00:00:00.000Z");
+    assertStart("2016-03-13T04:52:38.337Z", UTC, DAY, 3, "2016-03-13T00:00:00.000Z");
+    assertStart("2016-04-13T06:52:38.337Z", UTC, DAY, 5, "2016-04-11T00:00:00.000Z");
+    assertStart("2016-05-13T08:52:38.337Z", UTC, DAY, 7, "2016-05-08T00:00:00.000Z");
+    assertStart("2016-06-13T10:52:38.337Z", UTC, DAY, 14, "2016-06-01T00:00:00.000Z");
+    assertStart("2016-07-13T12:52:38.337Z", UTC, DAY, 30, "2016-07-01T00:00:00.000Z");
+    assertStart("2016-08-13T14:52:38.337Z", UTC, DAY, 1, "2016-08-13T00:00:00.000Z");
+    assertStart("2016-09-13T16:52:38.337Z", UTC, DAY, 2, "2016-09-13T00:00:00.000Z");
+    assertStart("2016-10-13T18:52:38.337Z", UTC, DAY, 3, "2016-10-13T00:00:00.000Z");
+    assertStart("2016-11-13T20:52:38.337Z", UTC, DAY, 5, "2016-11-11T00:00:00.000Z");
+    assertStart("2016-12-13T22:52:38.337Z", UTC, DAY, 7, "2016-12-08T00:00:00.000Z");
+  }
+
+  @Test
+  public void testDayIntervalStartPDT() throws Exception {
+    assertStart("2016-01-13T00:51:03.772-08:00", PDT, DAY, 1, "2016-01-13T00:00:00.000-08:00");
+    assertStart("2016-02-13T02:51:03.772-08:00", PDT, DAY, 2, "2016-02-13T00:00:00.000-08:00");
+    assertStart("2016-03-13T04:51:03.772-07:00", PDT, DAY, 3, "2016-03-13T00:00:00.000-08:00");
+    assertStart("2016-04-13T06:51:03.772-07:00", PDT, DAY, 5, "2016-04-11T00:00:00.000-07:00");
+    assertStart("2016-05-13T08:51:03.772-07:00", PDT, DAY, 7, "2016-05-08T00:00:00.000-07:00");
+    assertStart("2016-06-13T10:51:03.772-07:00", PDT, DAY, 14, "2016-06-01T00:00:00.000-07:00");
+    assertStart("2016-07-13T12:51:03.772-07:00", PDT, DAY, 30, "2016-07-01T00:00:00.000-07:00");
+    assertStart("2016-08-13T14:51:03.772-07:00", PDT, DAY, 1, "2016-08-13T00:00:00.000-07:00");
+    assertStart("2016-09-13T16:51:03.772-07:00", PDT, DAY, 2, "2016-09-13T00:00:00.000-07:00");
+    assertStart("2016-10-13T18:51:03.772-07:00", PDT, DAY, 3, "2016-10-13T00:00:00.000-07:00");
+    assertStart("2016-11-13T20:51:03.772-08:00", PDT, DAY, 5, "2016-11-11T00:00:00.000-08:00");
+    assertStart("2016-12-13T22:51:03.772-08:00", PDT, DAY, 7, "2016-12-08T00:00:00.000-08:00");
+  }
+
+  @Test
+  public void testHourIntervalStartUTC() throws Exception {
+    assertStart("2016-01-02T00:00:00.000Z", UTC, HOUR, 1, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T02:00:00.000Z", UTC, HOUR, 3, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T04:00:00.000Z", UTC, HOUR, 7, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T06:00:00.000Z", UTC, HOUR, 13, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T08:00:00.000Z", UTC, HOUR, 21, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T10:00:00.000Z", UTC, HOUR, 1, "2016-01-02T10:00:00.000Z");
+    assertStart("2016-01-02T12:00:00.000Z", UTC, HOUR, 3, "2016-01-02T12:00:00.000Z");
+    assertStart("2016-01-02T14:00:00.000Z", UTC, HOUR, 7, "2016-01-02T14:00:00.000Z");
+    assertStart("2016-01-02T16:00:00.000Z", UTC, HOUR, 13, "2016-01-02T13:00:00.000Z");
+    assertStart("2016-01-02T18:00:00.000Z", UTC, HOUR, 21, "2016-01-02T00:00:00.000Z");
+    assertStart("2016-01-02T20:00:00.000Z", UTC, HOUR, 1, "2016-01-02T20:00:00.000Z");
+    assertStart("2016-01-02T22:00:00.000Z", UTC, HOUR, 3, "2016-01-02T21:00:00.000Z");
+  }
+
+  @Test
+  public void testHourIntervalStartPDT() throws Exception {
+    assertStart("2016-01-02T00:00:00.000-08:00", PDT, HOUR, 1, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T02:00:00.000-08:00", PDT, HOUR, 3, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T04:00:00.000-08:00", PDT, HOUR, 7, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T06:00:00.000-08:00", PDT, HOUR, 13, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T08:00:00.000-08:00", PDT, HOUR, 21, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T10:00:00.000-08:00", PDT, HOUR, 1, "2016-01-02T10:00:00.000-08:00");
+    assertStart("2016-01-02T12:00:00.000-08:00", PDT, HOUR, 3, "2016-01-02T12:00:00.000-08:00");
+    assertStart("2016-01-02T14:00:00.000-08:00", PDT, HOUR, 7, "2016-01-02T14:00:00.000-08:00");
+    assertStart("2016-01-02T16:00:00.000-08:00", PDT, HOUR, 13, "2016-01-02T13:00:00.000-08:00");
+    assertStart("2016-01-02T18:00:00.000-08:00", PDT, HOUR, 21, "2016-01-02T00:00:00.000-08:00");
+    assertStart("2016-01-02T20:00:00.000-08:00", PDT, HOUR, 1, "2016-01-02T20:00:00.000-08:00");
+    assertStart("2016-01-02T22:00:00.000-08:00", PDT, HOUR, 3, "2016-01-02T21:00:00.000-08:00");
+  }
+
+  @Test
+  public void testWeekIntervalStartUTC() throws Exception {
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 1, "2016-04-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 2, "2016-03-25T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 3, "2016-03-25T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 11, "2016-03-18T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 26, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, WEEK, 50, "2016-01-01T00:00:00.000Z");
+  }
+
+  @Test
+  public void testWeekIntervalStartPDT() throws Exception {
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 1, "2016-04-01T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 2, "2016-03-25T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 3, "2016-03-25T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 11, "2016-03-18T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 26, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, WEEK, 50, "2016-01-01T00:00:00.000-08:00");
+  }
+
+  @Test
+  public void testMonthIntervalStartUTC() throws Exception {
+    assertStart("2016-04-05T00:00:00.000Z", UTC, MONTH, 1, "2016-04-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, MONTH, 2, "2016-03-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, MONTH, 3, "2016-04-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, MONTH, 7, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, MONTH, 12, "2016-01-01T00:00:00.000Z");
+  }
+
+  @Test
+  public void testMonthIntervalStartPDT() throws Exception {
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, MONTH, 1, "2016-04-01T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, MONTH, 2, "2016-03-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, MONTH, 3, "2016-04-01T00:00:00.000-07:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, MONTH, 7, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, MONTH, 12, "2016-01-01T00:00:00.000-08:00");
+  }
+
+  @Test
+  public void testYearIntervalStartUTC() throws Exception {
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 1, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 2, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 3, "2015-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 4, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 5, "2015-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 6, "2012-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 7, "2014-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 8, "2016-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 9, "2009-01-01T00:00:00.000Z");
+    assertStart("2016-04-05T00:00:00.000Z", UTC, YEAR, 10, "2010-01-01T00:00:00.000Z");
+  }
+
+  @Test
+  public void testYearIntervalStartPDT() throws Exception {
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 1, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 2, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 3, "2015-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 4, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 5, "2015-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 6, "2012-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 7, "2014-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 8, "2016-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 9, "2009-01-01T00:00:00.000-08:00");
+    assertStart("2016-04-05T00:00:00.000-07:00", PDT, YEAR, 10, "2010-01-01T00:00:00.000-08:00");
+  }
+
+  @Test
+  public void testHourGetTimeIntervalStartGap() throws Exception {
+    DateTimeZone timeZone = DateTimeZone.forID("America/Havana");
+
+    // Daylight saving causes a gap at midnight: time jumps from midnight to 1am on the 13th.
+    // This test checks that hourly code can correctly handle 00:00 not being a valid time.
+    assertStart("2016-03-13T15:09:26.535-0400", timeZone, HOUR, 1, "2016-03-13T15:00:00-0400");
+  }
+
+  @Test
+  public void testDayGetTimeIntervalStartGap() throws Exception {
+    DateTimeZone timeZone = DateTimeZone.forID("Asia/Amman");
+
+    // Daylight saving causes a gap at midnight: time jumps from midnight to 1am on the 1st.
+    // This test checks that daily code can correctly handle 04-01T00:00 not being a valid time.
+    assertStart("2016-04-12T15:09:26.535+0200", timeZone, DAY, 1, "2016-04-12T01:00:00.000+03:00");
+  }
+
+  private static void assertStart(
+    String date, DateTimeZone timeZone, TimeIntervalType type, int length, String expected
+  ) {
+    DateTime actual = type.getTimeIntervalStart(new DateTime(date, timeZone), length);
+
+    Assert.assertEquals(actual, new DateTime(expected, timeZone), length + " " + type);
+  }
+}


### PR DESCRIPTION
Replace `TimeIntervalType.clearField()` with `DateTimeFieldType.roundFloorCopy()`, since clearField() throws an exception if the time lies in a daylight-saving gap.

Several timezones have a daylight saving cutover of midnight: 00:00 becomes 01:00. The old implementation of `TimeIntervalType` truncated the time interval by setting each `subType` field to its minimum value. Unfortunately, if this time happened to correspond to a DST gap, then an `IllegalFieldValueException` exception would be thrown, e.g.:

    org.joda.time.IllegalFieldValueException: Value 0 for hourOfDay is not supported: Illegal instant due to time zone offset transition (daylight savings time 'gap'): 2016-03-13T00:00:00.000 (America/Havana)