### PR TITLE
[stats] Fix .COUNT counter values when calling getCounters()

### DIFF
--- a/stats/src/main/java/com/facebook/stats/StatsManager.java
+++ b/stats/src/main/java/com/facebook/stats/StatsManager.java
@@ -66,7 +66,7 @@ public class StatsManager implements HistoryManager {
    */
   public StatsManager(int initialNumKeys,
                       float loadFactor,
-                      int concurrencyLevel) 
+                      int concurrencyLevel)
   {
     logger.trace("StatsMgr Created");
     this.typeMap =
@@ -128,7 +128,8 @@ public class StatsManager implements HistoryManager {
     return;
   }
 
-  public void addStatExportType(String shortName, ExportType etype) {
+  @Override
+public void addStatExportType(String shortName, ExportType etype) {
     if (shortName == null) {
       logger.error("Null value passed as key");
       return;
@@ -141,7 +142,8 @@ public class StatsManager implements HistoryManager {
     ensureType(shortName, etype);
   }
 
-  public void addStatValue(String shortName, long delta) {
+  @Override
+public void addStatValue(String shortName, long delta) {
     if (!counterMap.containsKey(shortName)) {
       addStatExportType(shortName, ExportType.AVG);
     }
@@ -284,7 +286,7 @@ public class StatsManager implements HistoryManager {
   /**
    * fb303-support
    */
-  public Map<String, Long> getCounters() 
+  public Map<String, Long> getCounters()
   {
     Map<String, Long> result = new HashMap<String, Long>();
     String fullname;
@@ -304,7 +306,7 @@ public class StatsManager implements HistoryManager {
           value = stat.getMinuteSum();
           break;
         case COUNT:
-          value = stat.getMinuteSum();
+          value = stat.getMinuteSamples();
           break;
         case AVG:
           value = stat.getMinuteAvg();
@@ -324,7 +326,7 @@ public class StatsManager implements HistoryManager {
           value = stat.getTenMinuteSum();
           break;
         case COUNT:
-          value = stat.getTenMinuteSum();
+          value = stat.getTenMinuteSamples();
           break;
         case AVG:
           value = stat.getTenMinuteAvg();
@@ -344,7 +346,7 @@ public class StatsManager implements HistoryManager {
           value = stat.getHourSum();
           break;
         case COUNT:
-          value = stat.getHourSum();
+          value = stat.getHourSamples();
           break;
         case AVG:
           value = stat.getHourAvg();
@@ -364,7 +366,7 @@ public class StatsManager implements HistoryManager {
           value = stat.getAllTimeSum();
           break;
         case COUNT:
-          value = stat.getAllTimeSum();
+          value = stat.getAllTimeSamples();
           break;
         case AVG:
           value = stat.getAllTimeAvg();

--- a/stats/src/test/java/com/facebook/stats/TestStatsManager.java
+++ b/stats/src/test/java/com/facebook/stats/TestStatsManager.java
@@ -32,6 +32,12 @@ public class TestStatsManager {
     return result.toString();
   }
 
+  private void assertCounter(StatsManager stats, String name, long value) {
+    Assert.assertEquals(stats.getCounter(name), value);
+    Assert.assertNotNull(stats.getCounters().get(name));
+    Assert.assertEquals((long)stats.getCounters().get(name), value);
+  }
+
   @Test(groups="fast")
   public void TestBasic() throws Exception {
     System.out.println("Basic Test");
@@ -43,10 +49,10 @@ public class TestStatsManager {
     }
     System.out.println(toString(stats));
 
-    Assert.assertEquals(stats.getCounter("basic.avg"), amt);
-    Assert.assertEquals(stats.getCounter("basic.avg.60"), amt);
-    Assert.assertEquals(stats.getCounter("basic.avg.600"), amt);
-    Assert.assertEquals(stats.getCounter("basic.avg.3600"), amt);
+    assertCounter(stats, "basic.avg", amt);
+    assertCounter(stats, "basic.avg.60", amt);
+    assertCounter(stats, "basic.avg.600", amt);
+    assertCounter(stats, "basic.avg.3600", amt);
 
     stats.addStatExportType("test-sum", HistoryManager.ExportType.SUM);
     for (int i=0; i<num; i++) {
@@ -54,10 +60,10 @@ public class TestStatsManager {
     }
     System.out.println(toString(stats));
 
-    Assert.assertEquals(stats.getCounter("test-sum.sum"), num*amt);
-    Assert.assertEquals(stats.getCounter("test-sum.sum.60"), num*amt);
-    Assert.assertEquals(stats.getCounter("test-sum.sum.600"), num*amt);
-    Assert.assertEquals(stats.getCounter("test-sum.sum.3600"), num*amt);
+    assertCounter(stats, "test-sum.sum", num*amt);
+    assertCounter(stats, "test-sum.sum.60", num*amt);
+    assertCounter(stats, "test-sum.sum.600", num*amt);
+    assertCounter(stats, "test-sum.sum.3600", num*amt);
 
     stats.addStatExportType("test-rate", HistoryManager.ExportType.RATE);
     stats.addStatExportType("test-avg", HistoryManager.ExportType.AVG);
@@ -69,15 +75,15 @@ public class TestStatsManager {
     }
 
     System.out.println(toString(stats));
-    Assert.assertEquals(stats.getCounter("test-count.count"), num);
-    Assert.assertEquals(stats.getCounter("test-count.count.60"), num);
-    Assert.assertEquals(stats.getCounter("test-count.count.600"), num);
-    Assert.assertEquals(stats.getCounter("test-count.count.3600"), num);
+    assertCounter(stats, "test-count.count", num);
+    assertCounter(stats, "test-count.count.60", num);
+    assertCounter(stats, "test-count.count.600", num);
+    assertCounter(stats, "test-count.count.3600", num);
 
-    Assert.assertEquals(stats.getCounter("test-count.avg"), amt);
-    Assert.assertEquals(stats.getCounter("test-count.avg.60"), amt);
-    Assert.assertEquals(stats.getCounter("test-count.avg.600"), amt);
-    Assert.assertEquals(stats.getCounter("test-count.avg.3600"), amt);
+    assertCounter(stats, "test-avg.avg", amt);
+    assertCounter(stats, "test-avg.avg.60", amt);
+    assertCounter(stats, "test-avg.avg.600", amt);
+    assertCounter(stats, "test-avg.avg.3600", amt);
 
     stats.addStatExportType("test-all", HistoryManager.ExportType.SUM);
     stats.addStatExportType("test-all", HistoryManager.ExportType.RATE);
@@ -89,8 +95,8 @@ public class TestStatsManager {
     stats.addStatValue("test-all", amt);
 
     System.out.println(toString(stats));
-    Assert.assertEquals(stats.getCounter("test-all.sum"), amt+amt);
-    Assert.assertEquals(stats.getCounter("test-all.avg"), amt);
-    Assert.assertEquals(stats.getCounter("test-all.count"), 2);
+    assertCounter(stats, "test-all.sum", amt+amt);
+    assertCounter(stats, "test-all.avg", amt);
+    assertCounter(stats, "test-all.count", 2);
   }
 }


### PR DESCRIPTION
StatsManager.getCounters() should return the number of samples for
.COUNT counters. However, it returned the sum. Fixing this. This
is the same issue as in #39, but #39 only fixed the getCounter(String)
method, not the method that returns a map of counters

Updated unit test to check both getCounter() and getCounters().
Also fixed a counter name for avg testing.