### PR TITLE
Hotfix/squid.s2293

### DIFF
--- a/collections-foundation/src/main/java/com/facebook/collectionsbase/Piles.java
+++ b/collections-foundation/src/main/java/com/facebook/collectionsbase/Piles.java
@@ -40,7 +40,7 @@ public class Piles {
    * @return
    */
   public static <X, Y> List<Y> transmogrify(Iterator<X> iterator, Function<X, Y> function) {
-    com.facebook.collectionsbase.Mapper<X, Y> mapper = new com.facebook.collectionsbase.FunctionToMapper<X, Y>(function);
+    com.facebook.collectionsbase.Mapper<X, Y> mapper = new com.facebook.collectionsbase.FunctionToMapper<>(function);
 
     return transmogrify(iterator, mapper);
   }
@@ -70,7 +70,7 @@ public class Piles {
    * @return
    */
   public static <T> List<T> copyOf(Iterator<T> iterator) {
-    List<T> result = new ArrayList<T>();
+    List<T> result = new ArrayList<>();
 
     copyOf(iterator, result);
 

--- a/collections/src/main/java/com/facebook/collections/DynamicIterator.java
+++ b/collections/src/main/java/com/facebook/collections/DynamicIterator.java
@@ -39,7 +39,7 @@ public class DynamicIterator<T> extends AbstractIterator<T> {
   public DynamicIterator(int initialSize) {
     Preconditions.checkArgument(initialSize >= 0, "initialSize must be >= 0");
 
-    this.queue = new ArrayDeque<T>(initialSize);
+    this.queue = new ArrayDeque<>(initialSize);
   }
 
   public DynamicIterator() {

--- a/collections/src/main/java/com/facebook/collections/ListMapper.java
+++ b/collections/src/main/java/com/facebook/collections/ListMapper.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 public class ListMapper {
   public static <X,Y> List<Y> map(List<X> list, Mapper<X, Y> mapper) {
-    List<Y> result = new ArrayList<Y>();
+    List<Y> result = new ArrayList<>();
 
     for (X item : list) {
       result.add(mapper.map(item));

--- a/collections/src/main/java/com/facebook/collections/PackedByteArray.java
+++ b/collections/src/main/java/com/facebook/collections/PackedByteArray.java
@@ -56,7 +56,7 @@ public class PackedByteArray {
 
     // 256 magic number--just guessing it won't be bigger. If it is,
     // ArrayList will resize
-    List<Byte> byteList = new ArrayList<Byte>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
+    List<Byte> byteList = new ArrayList<>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
     byte b;
 
     while ((b = in.readByte()) != terminalDelimiter) {
@@ -83,7 +83,7 @@ public class PackedByteArray {
 
     // 256 magic number--just guessing it won't be bigger. If it is,
     // ArrayList will resize
-    List<Byte> byteList = new ArrayList<Byte>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
+    List<Byte> byteList = new ArrayList<>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
     byte b;
 
     while ((b = in.readByte()) != terminalDelimiter) {
@@ -169,9 +169,9 @@ public class PackedByteArray {
   public static List<byte[]> unpackComparable(
     byte[] packedArray, byte delimiter, byte terminalDelimiter
   ) {
-    List<byte[]> results = new ArrayList<byte[]>();
+    List<byte[]> results = new ArrayList<>();
     List<Byte> currentToken =
-      new ArrayList<Byte>(MAGIC_INITIAL_BYTE_ARRAY_SIZE); // very magic
+      new ArrayList<>(MAGIC_INITIAL_BYTE_ARRAY_SIZE); // very magic
 
     for (int i = 0; i < packedArray.length; i++) {
       if (packedArray[i] == terminalDelimiter) {
@@ -181,7 +181,7 @@ public class PackedByteArray {
       } else if (packedArray[i] == delimiter) {
         // end of an element, store and move to next
         results.add(byteListToArray(currentToken));
-        currentToken = new ArrayList<Byte>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
+        currentToken = new ArrayList<>(MAGIC_INITIAL_BYTE_ARRAY_SIZE);
       } else {
         // put byte into current array
         currentToken.add(packedArray[i]);
@@ -197,7 +197,7 @@ public class PackedByteArray {
    * {@literal
    * <numItems><len1,len2,...len_n><item1,item2,...item_n> }
    *
-   * @param arrayList
+   * @param arrays
    * @return packed byte array
    */
   public static byte[] pack(List<byte[]> arrays) {

--- a/collections/src/main/java/com/facebook/collections/PriorityQueueHeap.java
+++ b/collections/src/main/java/com/facebook/collections/PriorityQueueHeap.java
@@ -65,7 +65,7 @@ public class PriorityQueueHeap<T> implements SimpleHeap<T> {
    */
   @Override
   public int shrink() {
-    PriorityQueue<T> newPriorityQueue = new PriorityQueue<T>(priorityQueue);
+    PriorityQueue<T> newPriorityQueue = new PriorityQueue<>(priorityQueue);
     
     priorityQueue = newPriorityQueue;
     // unfortunately, we don't know the # of slots saved, so we still return 0
@@ -76,7 +76,7 @@ public class PriorityQueueHeap<T> implements SimpleHeap<T> {
   @Override
   public SimpleHeap<T> makeCopy() {
     // deep copy
-    return new PriorityQueueHeap<T>(new PriorityQueue<T>(priorityQueue));
+    return new PriorityQueueHeap<>(new PriorityQueue<>(priorityQueue));
   }
 
   @Override

--- a/collections/src/main/java/com/facebook/collections/RangeSet.java
+++ b/collections/src/main/java/com/facebook/collections/RangeSet.java
@@ -32,7 +32,7 @@ public class RangeSet extends AbstractSet<Long> implements Set<Long> {
   /**
    * Map that indexes each LongSegment with the smallest value in its range
    */
-  private final NavigableMap<Long, LongSegment> map = new TreeMap<Long, LongSegment>();
+  private final NavigableMap<Long, LongSegment> map = new TreeMap<>();
   private int size = 0;
 
   @Override

--- a/collections/src/main/java/com/facebook/collections/SetMapImpl.java
+++ b/collections/src/main/java/com/facebook/collections/SetMapImpl.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class SetMapImpl<K, V, S extends Set<V>> implements SetMap<K,V,S> {
   private final ConcurrentMap<K, S> sets =
-    new ConcurrentHashMap<K, S>();
+    new ConcurrentHashMap<>();
   private final ReadWriteLock removalLock = new ReentrantReadWriteLock();
   private final SetFactory<V, S> setFactory;
 

--- a/collections/src/main/java/com/facebook/collections/TranslatingIterable.java
+++ b/collections/src/main/java/com/facebook/collections/TranslatingIterable.java
@@ -30,6 +30,6 @@ public class TranslatingIterable<X, Y> implements Iterable<Y> {
 
   @Override
   public Iterator<Y> iterator() {
-    return new TranslatingIterator<X,Y>(mapper, iterable.iterator());
+    return new TranslatingIterator<>(mapper, iterable.iterator());
   }
 }

--- a/collections/src/main/java/com/facebook/collections/specialized/HashSetFactory.java
+++ b/collections/src/main/java/com/facebook/collections/specialized/HashSetFactory.java
@@ -23,6 +23,6 @@ import java.util.Set;
 public class HashSetFactory<T> implements SetFactory<T, Set<T>> {
   @Override
   public Set<T> create() {
-    return new HashSet<T>(64);
+    return new HashSet<>(64);
   }
 }

--- a/collections/src/main/java/com/facebook/collections/specialized/LongHashSet.java
+++ b/collections/src/main/java/com/facebook/collections/specialized/LongHashSet.java
@@ -540,7 +540,7 @@ public class LongHashSet implements SnapshotableSet<Long>, Trackable {
 
   @Override
   public SnapshotableSet<Long> makeTransientSnapshot() {
-    return new SnapshotableSetImpl<Long>(
+    return new SnapshotableSetImpl<>(
       Collections.<Long>synchronizedSet(new HashSet<Long>(this)),
       new SnapshotableSetImplFactory<Long>(new HashSetFactory<Long>())
     );

--- a/collections/src/main/java/com/facebook/collections/specialized/SampledSetImpl.java
+++ b/collections/src/main/java/com/facebook/collections/specialized/SampledSetImpl.java
@@ -247,7 +247,7 @@ public class SampledSetImpl<T> implements SampledSet<T> {
       downSampleLock.readLock().unlock();
     }
 
-    return new SampledSetSnapshot<T>(setCopySampleRate, maxSetSize, setCopy);
+    return new SampledSetSnapshot<>(setCopySampleRate, maxSetSize, setCopy);
   }
 
   @Override
@@ -421,7 +421,7 @@ public class SampledSetImpl<T> implements SampledSet<T> {
 
   @Override
   public SampledSet<T> makeSnapshot() {
-    return new SampledSetImpl<T>(
+    return new SampledSetImpl<>(
       maxSetSize,
       digestFunction,
       baseSet.makeSnapshot(),
@@ -433,10 +433,10 @@ public class SampledSetImpl<T> implements SampledSet<T> {
   @Override
   public SampledSet<T> makeTransientSnapshot() {
     SnapshotableSetImplFactory<T> cpuEfficientHashSetFactory =
-      new SnapshotableSetImplFactory<T>(new HashSetFactory<T>());
+      new SnapshotableSetImplFactory<>(new HashSetFactory<T>());
     SnapshotableSet<T> cpuEfficientHashSet = baseSet.makeTransientSnapshot();
 
-    return new SampledSetImpl<T>(
+    return new SampledSetImpl<>(
       maxSetSize,
       digestFunction,
       cpuEfficientHashSet,

--- a/collections/src/main/java/com/facebook/collections/specialized/SnapshotableSetImplFactory.java
+++ b/collections/src/main/java/com/facebook/collections/specialized/SnapshotableSetImplFactory.java
@@ -29,6 +29,6 @@ public class SnapshotableSetImplFactory<T> implements SetFactory<T, Snapshotable
 
   @Override
   public SnapshotableSet<T> create() {
-    return new SnapshotableSetImpl<T>(factory.create(), this);
+    return new SnapshotableSetImpl<>(factory.create(), this);
   }
 }

--- a/collections/src/main/java/com/facebook/collections/specialized/TrackableSetMap.java
+++ b/collections/src/main/java/com/facebook/collections/specialized/TrackableSetMap.java
@@ -51,7 +51,7 @@ public class TrackableSetMap<K, V, S extends Set<V>>
   }
 
   public TrackableSetMap(SetFactory<V, S> setFactory) {
-    delegate = new SetMapImpl<K, V, S>(setFactory);
+    delegate = new SetMapImpl<>(setFactory);
   }
 
   @Override

--- a/concurrency/src/main/java/com/facebook/concurrency/CallableSnapshotFunctionImpl.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/CallableSnapshotFunctionImpl.java
@@ -34,7 +34,7 @@ public class CallableSnapshotFunctionImpl<I, O, E extends Exception> implements
   public CallableSnapshotFunctionImpl(ValueFactory<I, O, E> valueFactory) {
     // We can cast exceptions because the value factory declares which type
     // of exceptions it can throw on creation
-    this(valueFactory, new CastingExceptionHandler<E>());
+    this(valueFactory, new CastingExceptionHandler<>());
   }
 
   @Override

--- a/concurrency/src/main/java/com/facebook/concurrency/ConcurrencyUtil.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/ConcurrencyUtil.java
@@ -134,7 +134,7 @@ public class ConcurrencyUtil {
     final ExceptionHandler<E> exceptionHandler,
     String baseName
   ) throws E {
-    final AtomicReference<E> exception = new AtomicReference<E>();
+    final AtomicReference<E> exception = new AtomicReference<>();
     Iterator<Runnable> wrappedIterator =
       Iterators.transform(tasksIter, new ShortCircuitRunnable<>(exception, exceptionHandler));
 

--- a/concurrency/src/main/java/com/facebook/concurrency/ExecutorServiceFront.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/ExecutorServiceFront.java
@@ -72,7 +72,7 @@ public class ExecutorServiceFront extends AbstractExecutorService {
     this.executor = executor;
     this.poolName = poolName;
     this.maxTimeSliceMillis = maxTimeSliceUnit.toMillis(maxTimeSlice);
-    drainerList = new ArrayBlockingQueue<Drainer>(maxDrainers);
+    drainerList = new ArrayBlockingQueue<>(maxDrainers);
     
     for (int i = 0; i < maxDrainers; i++) {
       drainerList.add(new Drainer(String.format("%s-%03d", poolName, i)));

--- a/concurrency/src/main/java/com/facebook/concurrency/ParallelRunner.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/ParallelRunner.java
@@ -142,7 +142,7 @@ public class ParallelRunner {
     final ExceptionHandler<E> exceptionHandler,
     String baseName
   ) throws E {
-    final AtomicReference<E> exception = new AtomicReference<E>();
+    final AtomicReference<E> exception = new AtomicReference<>();
     Iterator<Runnable> wrappedIterator =
       Iterators.transform(tasksIter, new ShortCircuitRunnable<>(exception, exceptionHandler));
 

--- a/concurrency/src/main/java/com/facebook/concurrency/TaskGroup.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/TaskGroup.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 public class TaskGroup {
   private final ExecutorService defaultExecutor;
   private final Collection<Pair<ExecutorService, Runnable>> taskPairs =
-    new ArrayList<Pair<ExecutorService, Runnable>>();
+    new ArrayList<>();
 
   public TaskGroup(ExecutorService defaultExecutor) {
     this.defaultExecutor = defaultExecutor;

--- a/concurrency/src/main/java/com/facebook/concurrency/UnstoppableExecutorServiceCore.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/UnstoppableExecutorServiceCore.java
@@ -44,7 +44,7 @@ class UnstoppableExecutorServiceCore {
       throw new RejectedExecutionException("executor shutdown already");
     }
 
-    List<Runnable> result = new ArrayList<Runnable>();
+    List<Runnable> result = new ArrayList<>();
 
     for (Runnable task : taskList) {
       result.add(new TrackedRunnableImpl(task));
@@ -60,7 +60,7 @@ class UnstoppableExecutorServiceCore {
       throw new RejectedExecutionException("executor shutdown already");
     }
 
-    List<TrackedCallable<V>> result = new ArrayList<TrackedCallable<V>>();
+    List<TrackedCallable<V>> result = new ArrayList<>();
 
     for (Callable<V> task : taskList) {
       result.add(new TrackedCallableImpl<V>(task));
@@ -82,7 +82,7 @@ class UnstoppableExecutorServiceCore {
       throw new RejectedExecutionException("executor shutdown already");
     }
 
-    return new TrackedCallableImpl<V>(task);
+    return new TrackedCallableImpl<>(task);
   }
 
   private void decrementRemaining() {
@@ -150,13 +150,13 @@ class UnstoppableExecutorServiceCore {
   }
 
   public <V> Future<V> trackFuture(Future<V> future, Completable task) {
-    return new TrackedFuture<V>(future, task);
+    return new TrackedFuture<>(future, task);
   }
 
   public <V> ScheduledFuture<V> trackScheduledFuture(
     ScheduledFuture<V> future, Completable task
   ) {
-    return new TrackedScheduledFuture<V>(future, task);
+    return new TrackedScheduledFuture<>(future, task);
   }
 
   private class TrackedRunnableImpl implements TrackedRunnable {
@@ -254,7 +254,7 @@ class UnstoppableExecutorServiceCore {
 
     @Override
     public Future<V> map(Future<V> input) {
-      TrackedFuture<V> trackedFuture = new TrackedFuture<V>(input, completableList.get(index));
+      TrackedFuture<V> trackedFuture = new TrackedFuture<>(input, completableList.get(index));
 
       index++;
 

--- a/concurrency/src/main/java/com/facebook/concurrency/linearization/Linearizer.java
+++ b/concurrency/src/main/java/com/facebook/concurrency/linearization/Linearizer.java
@@ -94,9 +94,9 @@ public class Linearizer {
   private static final long COMPLETE_WAIT_TIME_SECONDS = 300; 
 
   private final AtomicReference<AtomicInteger> pointCountRef = 
-    new AtomicReference<AtomicInteger>(new AtomicInteger(0));
+    new AtomicReference<>(new AtomicInteger(0));
   private final AtomicReference<LinearizationPoint> lastLinearizationPointRef = 
-    new AtomicReference<LinearizationPoint>();
+    new AtomicReference<>();
 
   /**
    * creates an lock-object such that other objects of this type

--- a/config/src/main/java/com/facebook/config/dynamic/OptionImpl.java
+++ b/config/src/main/java/com/facebook/config/dynamic/OptionImpl.java
@@ -35,7 +35,7 @@ public class OptionImpl<V> implements Option<V> {
   }
 
   @Override
-  public V getValue() {
+  public synchronized V getValue() {
     return value;
   }
 

--- a/config/src/main/java/com/facebook/config/dynamic/StringOptions.java
+++ b/config/src/main/java/com/facebook/config/dynamic/StringOptions.java
@@ -27,7 +27,7 @@ public class StringOptions {
   private final ConcurrentMap<String, Option<String>> optionMap = Maps.newConcurrentMap();
 
   public Option<String> getOption(String key) {
-    Option<String> option = new OptionImpl<String>();
+    Option<String> option = new OptionImpl<>();
     Option<String> existing = optionMap.putIfAbsent(key, option);
 
     return existing == null ? option : existing;

--- a/data/src/main/java/com/facebook/data/types/DatumUtils.java
+++ b/data/src/main/java/com/facebook/data/types/DatumUtils.java
@@ -115,7 +115,7 @@ public class DatumUtils {
   public static MapDatum toMapDatum(LongDatum[] rawTuple, StringDatum[] keyNames) {
     assert rawTuple.length == keyNames.length;
 
-    Map<Datum, Datum> datumMap = new HashMap<Datum, Datum>(rawTuple.length);
+    Map<Datum, Datum> datumMap = new HashMap<>(rawTuple.length);
 
     for (int i = 0; i < rawTuple.length; i++) {
       datumMap.put(keyNames[i], rawTuple[i]);

--- a/data/src/main/java/com/facebook/data/types/ListDatum.java
+++ b/data/src/main/java/com/facebook/data/types/ListDatum.java
@@ -262,7 +262,7 @@ public class ListDatum implements Datum {
     public Datum deserialize(DataInput in) throws SerDeException {
       try {
         int numItems = in.readInt();
-        List<Datum> datumList = new ArrayList<Datum>(numItems);
+        List<Datum> datumList = new ArrayList<>(numItems);
 
         for (int i = 0; i < numItems; i++) {
           byte typeAsByte = in.readByte();

--- a/stats/src/main/java/com/facebook/stats/AbstractCompositeCounter.java
+++ b/stats/src/main/java/com/facebook/stats/AbstractCompositeCounter.java
@@ -53,7 +53,7 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
 
   // adds/removes to eventCounters happen only when synchronized on "this"
   @GuardedBy("this")
-  private final Deque<C> eventCounters = new ArrayDeque<C>();
+  private final Deque<C> eventCounters = new ArrayDeque<>();
   private final ReadableDuration maxLength;      // total window size
   private final ReadableDuration maxChunkLength; // size per counter
 
@@ -216,8 +216,8 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
   protected synchronized <C2 extends CompositeEventCounterIf<C>> C2 internalMerge(
     Collection<? extends C> otherCounters, C2 mergedCounter
   ) {
-    PeekableIterator<C> iter1 = new PeekableIterator<C>(eventCounters.iterator());
-    PeekableIterator<C> iter2 = new PeekableIterator<C>(otherCounters.iterator());
+    PeekableIterator<C> iter1 = new PeekableIterator<>(eventCounters.iterator());
+    PeekableIterator<C> iter2 = new PeekableIterator<>(otherCounters.iterator());
 
     while (iter1.hasNext() || iter2.hasNext()) {
       if (iter1.hasNext() && iter2.hasNext()) {
@@ -321,7 +321,7 @@ public abstract class AbstractCompositeCounter<C extends EventCounterIf<C>>
    */
   @Deprecated
   protected synchronized List<C> getEventCountersCopy() {
-    return new ArrayList<C>(eventCounters);
+    return new ArrayList<>(eventCounters);
   }
 
   /**

--- a/stats/src/main/java/com/facebook/stats/MultiWindowDistribution.java
+++ b/stats/src/main/java/com/facebook/stats/MultiWindowDistribution.java
@@ -102,7 +102,7 @@ public class MultiWindowDistribution implements WritableMultiWindowStat {
     Iterator<Quantile> keyIterator = keys.iterator();
     Iterator<Long> valueIterator = values.iterator();
 
-    EnumMap<Quantile, Long> result = new EnumMap<Quantile, Long>(Quantile.class);
+    EnumMap<Quantile, Long> result = new EnumMap<>(Quantile.class);
     while (keyIterator.hasNext() && valueIterator.hasNext()) {
       result.put(keyIterator.next(), valueIterator.next());
     }

--- a/stats/src/main/java/com/facebook/stats/StatsManager.java
+++ b/stats/src/main/java/com/facebook/stats/StatsManager.java
@@ -70,11 +70,11 @@ public class StatsManager implements HistoryManager {
   {
     logger.trace("StatsMgr Created");
     this.typeMap =
-      new ConcurrentHashMap<String, Integer>(initialNumKeys,
+      new ConcurrentHashMap<>(initialNumKeys,
                                              loadFactor,
                                              concurrencyLevel);
     this.counterMap =
-      new ConcurrentHashMap<String, MultiWindowGauge>(initialNumKeys,
+      new ConcurrentHashMap<>(initialNumKeys,
                                                       loadFactor,
                                                       concurrencyLevel);
   }
@@ -248,7 +248,7 @@ public void addStatValue(String shortName, long delta) {
    * fb303-support
    */
   public Map<String, Long> getSelectedCounters(List<String> keys) {
-    Map<String, Long> result = new HashMap<String, Long>();
+    Map<String, Long> result = new HashMap<>();
     for (String key : keys) {
       try {
         result.put(key, getCounter(key));
@@ -288,7 +288,7 @@ public void addStatValue(String shortName, long delta) {
    */
   public Map<String, Long> getCounters()
   {
-    Map<String, Long> result = new HashMap<String, Long>();
+    Map<String, Long> result = new HashMap<>();
     String fullname;
     long value;
     Set<String> typeKeys = typeMap.keySet();

--- a/stats/src/main/java/com/facebook/stats/cardinality/SortedStaticModel.java
+++ b/stats/src/main/java/com/facebook/stats/cardinality/SortedStaticModel.java
@@ -183,7 +183,7 @@ class SortedStaticModel implements Model {
   }
 
   private List<SymbolProbability> sortProbabilities(double[] probabilities) {
-    ArrayList<SymbolProbability> symbolProbabilities = new ArrayList<SymbolProbability>();
+    ArrayList<SymbolProbability> symbolProbabilities = new ArrayList<>();
     for (int symbol = 0; symbol < probabilities.length; symbol++) {
       symbolProbabilities.add(new SymbolProbability(symbol, probabilities[symbol]));
     }

--- a/stats/src/main/java/com/facebook/stats/mx/Stats.java
+++ b/stats/src/main/java/com/facebook/stats/mx/Stats.java
@@ -366,7 +366,7 @@ public class Stats implements StatsReader, StatsCollector {
   }
 
   private Map<String, String> materializeAttributes() {
-    Map<String, String> materializedAttributes = new HashMap<String, String>();
+    Map<String, String> materializedAttributes = new HashMap<>();
 
     for (Map.Entry<String, Callable<String>> entry : attributes.entrySet()) {
       try {

--- a/stats/src/main/java/com/facebook/stats/topk/ArrayBasedIntegerTopK.java
+++ b/stats/src/main/java/com/facebook/stats/topk/ArrayBasedIntegerTopK.java
@@ -57,7 +57,7 @@ public class ArrayBasedIntegerTopK implements TopK<Integer> {
         return Longs.compare(counts[i], counts[j]);
       }
     };
-    PriorityQueue<Integer> topK = new PriorityQueue<Integer>(k, comparator);
+    PriorityQueue<Integer> topK = new PriorityQueue<>(k, comparator);
 
     for (int key = 0; key < counts.length; ++key) {
       if (topK.size() < k) {
@@ -70,7 +70,7 @@ public class ArrayBasedIntegerTopK implements TopK<Integer> {
       }
     }
 
-    LinkedList<Integer> sortedTopK = new LinkedList<Integer>();
+    LinkedList<Integer> sortedTopK = new LinkedList<>();
 
     while (!topK.isEmpty()) {
       sortedTopK.addFirst(topK.poll());

--- a/stats/src/main/java/com/facebook/stats/topk/HashBasedTopK.java
+++ b/stats/src/main/java/com/facebook/stats/topk/HashBasedTopK.java
@@ -40,7 +40,7 @@ public class HashBasedTopK<T extends Comparable<T>> implements TopK<T> {
   public HashBasedTopK(int k) {
     this.k = k;
     // k is a decent guess to start with
-    counts = new HashMap<T, Long>(k);
+    counts = new HashMap<>(k);
   }
 
   @Override
@@ -64,7 +64,7 @@ public class HashBasedTopK<T extends Comparable<T>> implements TopK<T> {
         return Longs.compare(counts.get(key1), counts.get(key2));
       }
     };
-    PriorityQueue<T> topK = new PriorityQueue<T>(k, comparator);
+    PriorityQueue<T> topK = new PriorityQueue<>(k, comparator);
 
     for (Map.Entry<T, Long> entry : counts.entrySet()) {
       if (topK.size() < k) {
@@ -75,7 +75,7 @@ public class HashBasedTopK<T extends Comparable<T>> implements TopK<T> {
       }
     }
 
-    LinkedList<T> sortedTopK = new LinkedList<T>();
+    LinkedList<T> sortedTopK = new LinkedList<>();
 
     while (!topK.isEmpty()) {
       sortedTopK.addFirst(topK.poll());

--- a/stats/src/main/java/com/facebook/stats/topk/TreeBasedIntegerTopK.java
+++ b/stats/src/main/java/com/facebook/stats/topk/TreeBasedIntegerTopK.java
@@ -35,7 +35,7 @@ public class TreeBasedIntegerTopK implements TopK<Integer> {
   private final long[] counts;
   private final boolean[] isInTop;
   private final TreeSet<ComparablePair<Long, Integer>> topPairs =
-    new TreeSet<ComparablePair<Long, Integer>>();
+    new TreeSet<>();
   private long smallestTopCount = Long.MAX_VALUE;
 
   public TreeBasedIntegerTopK(int keySpaceSize, int k) {
@@ -63,17 +63,17 @@ public class TreeBasedIntegerTopK implements TopK<Integer> {
     counts[key] += count;
 
     if (isInTop[key]) {
-      topPairs.remove(new ComparablePair<Long, Integer>(currentCount, key));
-      topPairs.add(new ComparablePair<Long, Integer>(counts[key], key));
+      topPairs.remove(new ComparablePair<>(currentCount, key));
+      topPairs.add(new ComparablePair<>(counts[key], key));
     } else if (topPairs.size() < k) {
-      topPairs.add(new ComparablePair<Long, Integer>(counts[key], key));
+      topPairs.add(new ComparablePair<>(counts[key], key));
       isInTop[key] = true;
       smallestTopCount = Math.min(smallestTopCount, counts[key]);
     } else if (counts[key] > smallestTopCount) {
       ComparablePair<Long, Integer> smallestTopPair = topPairs.pollFirst();
 
       isInTop[smallestTopPair.getSecond()] = false;
-      topPairs.add(new ComparablePair<Long, Integer>(counts[key], key));
+      topPairs.add(new ComparablePair<>(counts[key], key));
       isInTop[key] = true;
       smallestTopCount = topPairs.first().getFirst();
     }
@@ -81,7 +81,7 @@ public class TreeBasedIntegerTopK implements TopK<Integer> {
 
   @Override
   public synchronized List<Integer> getTopK() {
-    LinkedList<Integer> topK = new LinkedList<Integer>();
+    LinkedList<Integer> topK = new LinkedList<>();
 
     for (ComparablePair<Long, Integer> pair : topPairs) {
       topK.addFirst(pair.getSecond());

--- a/stats/src/main/java/com/facebook/stats/topk/TreeBasedTopK.java
+++ b/stats/src/main/java/com/facebook/stats/topk/TreeBasedTopK.java
@@ -36,9 +36,9 @@ import java.util.TreeSet;
  */
 public class TreeBasedTopK<T extends Comparable<T>> implements TopK<T> {
   private final int k;
-  private final Map<T, Long> counts = new HashMap<T, Long>();
+  private final Map<T, Long> counts = new HashMap<>();
   private final Set<T> topKeys;
-  private final TreeSet<ComparablePair<Long, T>> topPairs = new TreeSet<ComparablePair<Long, T>>();
+  private final TreeSet<ComparablePair<Long, T>> topPairs = new TreeSet<>();
   private long smallestTopCount = Long.MAX_VALUE;
 
   public TreeBasedTopK(int k) {
@@ -70,17 +70,17 @@ public class TreeBasedTopK<T extends Comparable<T>> implements TopK<T> {
     counts.put(key, updatedCount);
 
     if (topKeys.contains(key)) {
-      topPairs.remove(new ComparablePair<Long, T>(currentCount, key));
-      topPairs.add(new ComparablePair<Long, T>(updatedCount, key));
+      topPairs.remove(new ComparablePair<>(currentCount, key));
+      topPairs.add(new ComparablePair<>(updatedCount, key));
     } else if (topPairs.size() < k) {
-      topPairs.add(new ComparablePair<Long, T>(updatedCount, key));
+      topPairs.add(new ComparablePair<>(updatedCount, key));
       topKeys.add(key);
       smallestTopCount = Math.min(smallestTopCount, updatedCount);
     } else if (updatedCount > smallestTopCount) {
       ComparablePair<Long, T> smallestTopPair = topPairs.pollFirst();
 
       topKeys.remove(smallestTopPair.getSecond());
-      topPairs.add(new ComparablePair<Long, T>(updatedCount, key));
+      topPairs.add(new ComparablePair<>(updatedCount, key));
       topKeys.add(key);
       smallestTopCount = topPairs.first().getFirst();
     }
@@ -88,7 +88,7 @@ public class TreeBasedTopK<T extends Comparable<T>> implements TopK<T> {
 
   @Override
   public synchronized List<T> getTopK() {
-    LinkedList<T> topK = new LinkedList<T>();
+    LinkedList<T> topK = new LinkedList<>();
 
     for (ComparablePair<Long, T> pair : topPairs) {
       topK.addFirst(pair.getSecond());

--- a/testing/src/main/java/com/facebook/testing/MockExecutor.java
+++ b/testing/src/main/java/com/facebook/testing/MockExecutor.java
@@ -36,7 +36,7 @@ public class MockExecutor implements ScheduledExecutorService {
     Collections.synchronizedList(new ArrayList<AnnotatedRunnable>());
   private final CountDownLatch latch = new CountDownLatch(1);
   private final IdentityHashMap<ScheduledFuture<?>, ScheduledFuture<?>> 
-    outstandingTasks = new IdentityHashMap<ScheduledFuture<?>, ScheduledFuture<?>>();
+    outstandingTasks = new IdentityHashMap<>();
 
   private volatile boolean rejectSubmission = false;
   private volatile boolean isShutdown = false;
@@ -78,7 +78,7 @@ public class MockExecutor implements ScheduledExecutorService {
 
     runnableList.add(new AnnotatedRunnable(command, delay, delay, unit));
 
-    return new MockScheduledFuture<Void>(toCallable(command));
+    return new MockScheduledFuture<>(toCallable(command));
   }
 
   private <T> Callable toCallable(final Runnable runnable, final T result) {
@@ -128,7 +128,7 @@ public class MockExecutor implements ScheduledExecutorService {
 
     runnableList.add(runnable);
 
-    MockScheduledFuture<Void> future = new MockScheduledFuture<Void>(
+    MockScheduledFuture<Void> future = new MockScheduledFuture<>(
       Executors.<Void>callable(runnable, (Void) null)
     );
 
@@ -150,7 +150,7 @@ public class MockExecutor implements ScheduledExecutorService {
 
     runnableList.add(runnable);
 
-    MockScheduledFuture<Void> future = new MockScheduledFuture<Void>(
+    MockScheduledFuture<Void> future = new MockScheduledFuture<>(
       Executors.<Void>callable(runnable, (Void) null)
     );
 
@@ -171,7 +171,7 @@ public class MockExecutor implements ScheduledExecutorService {
   public List<Runnable> shutdownNow() {
     cancelPendingTasks();
     
-    return new ArrayList<Runnable>(runnableList);
+    return new ArrayList<>(runnableList);
   }
 
   private void cancelPendingTasks() {
@@ -211,21 +211,21 @@ public class MockExecutor implements ScheduledExecutorService {
       }
     }));
     
-    return new MockScheduledFuture<T>(task);
+    return new MockScheduledFuture<>(task);
   }
 
   @Override
   public <T> Future<T> submit(Runnable task, T result) {
     runnableList.add(new AnnotatedRunnable(task));
 
-    return new MockScheduledFuture<T>(toCallable(task, result));
+    return new MockScheduledFuture<>(toCallable(task, result));
   }
 
   @Override
   public Future<?> submit(Runnable task) {
     runnableList.add(new AnnotatedRunnable(task));
 
-    return new MockScheduledFuture<Void>(toCallable(task));
+    return new MockScheduledFuture<>(toCallable(task));
   }
 
   @Override

--- a/testing/src/main/java/com/facebook/testing/TestUtils.java
+++ b/testing/src/main/java/com/facebook/testing/TestUtils.java
@@ -157,7 +157,7 @@ public class TestUtils {
    * @return
    */
   public static List<DateTime> generateMoments(DateTime baseDateTime, int count) {
-    List<DateTime> result = new ArrayList<DateTime>(count);
+    List<DateTime> result = new ArrayList<>(count);
 
     for (int i = 0; i < count; i++) {
       result.add(baseDateTime.plusSeconds(i));
@@ -184,7 +184,7 @@ public class TestUtils {
       timeZones.put(timeZone.getRawOffset(), dateTimeZone);
       timeZones.put(timeZone.getRawOffset() + timeZone.getDSTSavings(), dateTimeZone);
     }
-    Set<DateTimeZone> distinctZones = new HashSet<DateTimeZone>();
+    Set<DateTimeZone> distinctZones = new HashSet<>();
     for (Map.Entry<Integer, Collection<DateTimeZone>> entry : timeZones.asMap().entrySet()) {
       DateTimeZone fixedZone = null;
       DateTimeZone unfixedZone = null;

--- a/testing/src/main/java/com/facebook/testing/ThreadHelper.java
+++ b/testing/src/main/java/com/facebook/testing/ThreadHelper.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ThreadHelper {
   private static final Logger LOG = LoggerFactory.getLogger(ThreadHelper.class);
   
-  private final List<Throwable> exceptionList = new ArrayList<Throwable>();
+  private final List<Throwable> exceptionList = new ArrayList<>();
   
   public Thread doInThread(Runnable operation) {
     return doInThread(operation, null);

--- a/util/src/main/java/com/facebook/util/StreamImporter.java
+++ b/util/src/main/java/com/facebook/util/StreamImporter.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class StreamImporter {
   public static List<String> importLines(InputStream in) throws IOException {
-    List<String> lines = new ArrayList<String>();
+    List<String> lines = new ArrayList<>();
     BufferedReader buffered = new BufferedReader(new InputStreamReader(in));
     String line;
     while ((line = buffered.readLine()) != null)   {

--- a/util/src/main/java/com/facebook/util/TimeUtil.java
+++ b/util/src/main/java/com/facebook/util/TimeUtil.java
@@ -36,9 +36,9 @@ public class TimeUtil {
 
   static {
     ImmutableMap.Builder<String, DateTimeZone> timeZoneBuilder =
-      new ImmutableMap.Builder<String, DateTimeZone>();
+      new ImmutableMap.Builder<>();
     ImmutableMap.Builder<String, ISOChronology> chronologyBuilder =
-      new ImmutableMap.Builder<String, ISOChronology>();
+      new ImmutableMap.Builder<>();
 
     for (Object id : DateTimeZone.getAvailableIDs()) {
       String tz = (String) id;

--- a/zookeeper/src/main/java/com/facebook/zookeeper/ZkUtil.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/ZkUtil.java
@@ -60,7 +60,7 @@ public class ZkUtil {
   public static List<String> filterByPrefix(
     List<String> nodes, String... prefixes
   ) {
-    List<String> lockChildren = new ArrayList<String>();
+    List<String> lockChildren = new ArrayList<>();
     for (String child : nodes){
       for (String prefix : prefixes){
         if (child.startsWith(prefix)){

--- a/zookeeper/src/main/java/com/facebook/zookeeper/app/ZkApplication.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/app/ZkApplication.java
@@ -256,7 +256,7 @@ public abstract class ZkApplication {
     private volatile State state = State.PRESTART;
     private final Object transitionLock = new Object();
     private final Map<State, StateHandler> handlerCache =
-      new EnumMap<State, StateHandler>(State.class);
+      new EnumMap<>(State.class);
 
     private StateContext() {
       // Should be one entry per possible state

--- a/zookeeper/src/main/java/com/facebook/zookeeper/cmd/ZNodePruner.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/cmd/ZNodePruner.java
@@ -150,7 +150,7 @@ public class ZNodePruner extends ZkScript {
 
   private Set<String> expandToKeepSet(List<String> toKeep) {
     // Add all listed ZNodes as well as all of their ancestors
-    Set<String> keepSet = new HashSet<String>();
+    Set<String> keepSet = new HashSet<>();
     for (String pathStr : toKeep) {
       ZkGenericPath path = ZkGenericPath.parse("/", pathStr);
       Iterator<ZkGenericPath> lineageIter = path.lineageIterator();

--- a/zookeeper/src/main/java/com/facebook/zookeeper/connection/ZkConnectionManagerImpl.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/connection/ZkConnectionManagerImpl.java
@@ -40,7 +40,7 @@ public class ZkConnectionManagerImpl implements ZkConnectionManager {
 
   private final ZooKeeperFactory zooKeeperFactory;
   private final List<Watcher> registeredWatchers =
-    new CopyOnWriteArrayList<Watcher>();
+    new CopyOnWriteArrayList<>();
   private final ConnectionWatcher connectionWatcher = new ConnectionWatcher();
   private final ConnectionRenewer connectionRenewer =
     new ConnectionRenewer();

--- a/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockWatcher.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockWatcher.java
@@ -22,7 +22,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 public class MockWatcher implements Watcher {
-  private Queue<WatchedEvent> eventQueue = new LinkedList<WatchedEvent>();
+  private Queue<WatchedEvent> eventQueue = new LinkedList<>();
 
   public Queue<WatchedEvent> getEventQueue() {
     return eventQueue;

--- a/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockZkConnectionManager.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockZkConnectionManager.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class MockZkConnectionManager implements ZkConnectionManager {
   private final ZooKeeperFactory zooKeeperFactory;
   private ZooKeeperIface zk;
-  private final List<Watcher> watchers = new ArrayList<Watcher>();
+  private final List<Watcher> watchers = new ArrayList<>();
   private boolean isShutdown = false;
 
   public MockZkConnectionManager(ZooKeeperFactory zooKeeperFactory) {

--- a/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockZooKeeperDataStore.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/mock/MockZooKeeperDataStore.java
@@ -45,7 +45,7 @@ public class MockZooKeeperDataStore {
   private final AtomicLong nextSessionId = new AtomicLong(0);
   private final ZNode root = ZNode.createRoot();
   private final Map<String, RetrieveableSet<ContextedWatcher>> creationWatchers =
-    new HashMap<String, RetrieveableSet<ContextedWatcher>>();
+    new HashMap<>();
 
   public long getUniqueSessionId() {
     return nextSessionId.addAndGet(1);
@@ -177,7 +177,7 @@ public class MockZooKeeperDataStore {
     if (watcher != null) {
       node.addWatcher(sessionId, watcher, WatchTriggerPolicy.WatchType.GETCHILDREN);
     }
-    return new ArrayList<String>(node.getChildren().keySet());
+    return new ArrayList<>(node.getChildren().keySet());
   }
 
   private static boolean isRootPath(String path) {
@@ -233,9 +233,9 @@ public class MockZooKeeperDataStore {
     private final Stat stat = new Stat();
     private final AtomicLong nextSeqNum = new AtomicLong(0);
     private final AtomicInteger version = new AtomicInteger(0);
-    private final Map<String, ZNode> children = new HashMap<String, ZNode>();
+    private final Map<String, ZNode> children = new HashMap<>();
     private final RetrieveableSet<ContextedWatcher> contextedWatchers =
-      new RetrieveableSet<ContextedWatcher>();
+      new RetrieveableSet<>();
 
     private ZNode(
       long sessionId,
@@ -488,7 +488,7 @@ public class MockZooKeeperDataStore {
       private ZNodeTreeIterator(ZNode initialZNode) {
         this.initialZNode = initialZNode;
         List<ZNode> childrenCopy =
-          new ArrayList<ZNode>(initialZNode.getChildren().values());
+          new ArrayList<>(initialZNode.getChildren().values());
         childIter = childrenCopy.iterator();
       }
 
@@ -633,7 +633,7 @@ public class MockZooKeeperDataStore {
 
     private static Map<WatchType, Set<EventType>> constructMapping() {
       Map<WatchType, Set<EventType>> mapping =
-        new EnumMap<WatchType, Set<EventType>>(WatchType.class);
+        new EnumMap<>(WatchType.class);
       mapping.put(WatchType.EXISTS,
         EnumSet.of(
           EventType.NodeCreated,

--- a/zookeeper/src/main/java/com/facebook/zookeeper/path/ZkPathCoreBuilder.java
+++ b/zookeeper/src/main/java/com/facebook/zookeeper/path/ZkPathCoreBuilder.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class ZkPathCoreBuilder {
   private final String appRoot;
-  private final List<String> zNodes = new ArrayList<String>();
+  private final List<String> zNodes = new ArrayList<>();
 
   public ZkPathCoreBuilder(ZkPathCore basePathCore) {
     this(basePathCore.getAppRoot());


### PR DESCRIPTION
Code cleanup for squid:S2293 impacting a variety of classes.

Java 7 introduced the diamond operator (<>) to reduce the verbosity of generics code. For instance, instead of having to declare a List's type in both its declaration and its constructor, you can now simplify the constructor declaration with <>, and the compiler will infer the type.

There was also one javadoc cleanup as well - the javadoc comment referenced a method argument that had changed its name. This was for method pack() in the class PackedByteArray.
