### PR TITLE
Adding java.util.function style interfaces that can throw.

### DIFF
--- a/util/src/main/java/com/facebook/util/ExceptionUtils.java
+++ b/util/src/main/java/com/facebook/util/ExceptionUtils.java
@@ -24,7 +24,7 @@ public class ExceptionUtils {
 
   public static <T extends Exception, S extends Exception> T wrap(S e, Class<T> clazz) {
     if (clazz.isAssignableFrom(e.getClass())) {
-      return (T) e;
+      return clazz.cast(e);
     }
 
     try {

--- a/util/src/main/java/com/facebook/util/ExtRunnable.java
+++ b/util/src/main/java/com/facebook/util/ExtRunnable.java
@@ -15,6 +15,8 @@
  */
 package com.facebook.util;
 
+import com.facebook.util.exceptions.UncheckedCheckedException;
+
 /**
  * extended runnable that throws an exception. Does not a produce a value
  * (hence not a Callable)
@@ -22,5 +24,17 @@ package com.facebook.util;
  * @param <E> type of exception you want to be able to throw
  */
 public interface ExtRunnable<E extends Throwable>{
-  public void run() throws E;
+  void run() throws E;
+  
+  static Runnable quiet(ExtRunnable<?> runnable) {
+    return () -> {
+      try {
+        runnable.run();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
+  }
 }

--- a/util/src/main/java/com/facebook/util/ExtSupplier.java
+++ b/util/src/main/java/com/facebook/util/ExtSupplier.java
@@ -15,7 +15,21 @@
  */
 package com.facebook.util;
 
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.util.function.Supplier;
+
 public interface ExtSupplier<T, E extends Throwable> {
   T get() throws E;
+  
+  public static <T> Supplier<T> quiet(ExtSupplier<T, ?> supplier) {
+    return () -> {
+      try {
+        return supplier.get();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
+  }
 }
-

--- a/util/src/main/java/com/facebook/util/exceptions/UncheckedCheckedException.java
+++ b/util/src/main/java/com/facebook/util/exceptions/UncheckedCheckedException.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.exceptions;
 
-import java.util.concurrent.Callable;
+/**
+ * This exception represents a checked exception that was caught and re-thrown as a {@link RuntimeException}.
+ */
+public class UncheckedCheckedException extends RuntimeException {
+  private static final long serialVersionUID = 1L;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  public UncheckedCheckedException(Throwable t) {
+    super(t);
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtBiConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtBiConsumer.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtBiConsumer<T, U, E extends Throwable> {
+  void accept(T t, U u) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  default ExtBiConsumer<T, U, E> andThen(ExtBiConsumer<? super T, ? super U, E> after) {
+    Objects.requireNonNull(after);
+    return (l, r) -> {
+      accept(l, r);
+      after.accept(l, r);
+    };
+  }
+  
+  static <T, U> BiConsumer<T, U> quiet(ExtBiConsumer<T, U, ?> biConsumer) {
+    return (t, u) -> ExtRunnable.quiet(() -> biConsumer.accept(t, u)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtBiFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtBiFunction.java
@@ -13,14 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtSupplier;
+import java.util.Objects;
+import java.util.function.BiFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtBiFunction<T, U, R, E extends Throwable> {
+  R apply(T t, U u) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  default <V> ExtBiFunction<T, U, V, E> andThen(ExtFunction<? super R, ? extends V, E> after) {
+    Objects.requireNonNull(after);
+    return (t, u) -> after.apply(apply(t, u));
+  }
+  
+  static <T, U, R> BiFunction<T, U, R> quiet(ExtBiFunction<T, U, R, ?> biFunction) {
+    return (t, u) -> ExtSupplier.quiet(() -> biFunction.apply(t, u)).get();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtBiPredicate.java
+++ b/util/src/main/java/com/facebook/util/function/ExtBiPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.BiPredicate;
+
+public interface ExtBiPredicate<T, U, E extends Throwable> {
+  boolean test(T t, U u) throws E;
+  
+  default ExtBiPredicate<T, U, E> and(ExtBiPredicate<? super T, ? super U, E> other) {
+    Objects.requireNonNull(other);
+    return (t, u) -> test(t, u) && other.test(t, u);
+  }
+  
+  default ExtBiPredicate<T, U, E> negate() {
+    return (t, u) -> !test(t, u);
+  }
+  
+  default ExtBiPredicate<T, U, E> or(ExtBiPredicate<? super T, ? super U, E> other) {
+    Objects.requireNonNull(other);
+    return (t, u) -> test(t, u) || other.test(t, u);
+  }
+  
+  static <T, U> BiPredicate<T, U> quiet(ExtBiPredicate<T, U, ?> biPredicate) {
+    return (t, u) -> ExtBooleanSupplier.quiet(() -> biPredicate.test(t, u)).getAsBoolean();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtBinaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtBinaryOperator.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.BinaryOperator;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public interface ExtBinaryOperator<T, E extends Throwable> extends ExtBiFunction<T, T, T, E> {
+  static <T> BinaryOperator<T> quiet(ExtBinaryOperator<T, ?> binaryOperator) {
+    return (a, b) -> ExtBiFunction.quiet(binaryOperator).apply(a, b);
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtBooleanSupplier.java
+++ b/util/src/main/java/com/facebook/util/function/ExtBooleanSupplier.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.util.function.BooleanSupplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtBooleanSupplier<E extends Throwable> {
+  boolean getAsBoolean() throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static BooleanSupplier quiet(ExtBooleanSupplier<?> booleanSupplier) {
+    return () -> {
+      try {
+        return booleanSupplier.getAsBoolean();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtConsumer.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.Objects;
+import java.util.function.Consumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtConsumer<T, E extends Throwable> {
+  void accept(T t) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  default ExtConsumer<T, E> andThen(ExtConsumer<? super T, E> after) {
+    Objects.requireNonNull(after);
+    return (t) -> {
+      accept(t);
+      after.accept(t);
+    };
+  }
+  
+  static <T> Consumer<T> quiet(ExtConsumer<T, ?> consumer) {
+    return (t) -> ExtRunnable.quiet(() -> consumer.accept(t)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleBinaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleBinaryOperator.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.DoubleBinaryOperator;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleBinaryOperator<E extends Throwable> {
+  double applyAsDouble(double left, double right) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static DoubleBinaryOperator quiet(ExtDoubleBinaryOperator<?> doubleBinaryOperator) {
+    return (left, right) ->
+        ExtDoubleSupplier.quiet(() -> doubleBinaryOperator.applyAsDouble(left, right)).getAsDouble();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleConsumer.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.Objects;
+import java.util.function.DoubleConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleConsumer<E extends Throwable> {
+  void accept(double value);
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  default ExtDoubleConsumer<E> andThen(ExtDoubleConsumer<E> after) {
+    Objects.requireNonNull(after);
+    return (t) -> {
+      accept(t);
+      after.accept(t);
+    };
+  }
+  
+  static DoubleConsumer quiet(ExtDoubleConsumer<?> doubleConsumer) {
+    return (value) -> ExtRunnable.quiet(() -> doubleConsumer.accept(value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleFunction.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtSupplier;
+import java.util.function.DoubleFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleFunction<R, E extends Throwable> {
+  R apply(double value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <R> DoubleFunction<R> quiet(ExtDoubleFunction<R, ?> doubleFunction) {
+    return (value) -> ExtSupplier.quiet(() -> doubleFunction.apply(value)).get();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoublePredicate.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoublePredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.DoublePredicate;
+
+public interface ExtDoublePredicate<E extends Throwable> {
+  boolean test(double value) throws E;
+  
+  default ExtDoublePredicate<E> and(ExtDoublePredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) && other.test(value);
+  }
+  
+  default ExtDoublePredicate<E> negate() {
+    return (value) -> !test(value);
+  }
+  
+  default ExtDoublePredicate<E> or(ExtDoublePredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) || other.test(value);
+  }
+  
+  static DoublePredicate quiet(ExtDoublePredicate<?> doublePredicate) {
+    return (value) -> ExtBooleanSupplier.quiet(() -> doublePredicate.test(value)).getAsBoolean();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleSupplier.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleSupplier.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.util.function.DoubleSupplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleSupplier<E extends Throwable> {
+  double getAsDouble() throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static DoubleSupplier quiet(ExtDoubleSupplier<?> doubleSupplier) {
+    return () -> {
+      try {
+        return doubleSupplier.getAsDouble();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleToIntFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleToIntFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.DoubleToIntFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleToIntFunction<E extends Throwable> {
+  int applyAsInt(double value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static DoubleToIntFunction quiet(ExtDoubleToIntFunction<?> doubleToIntFunction) {
+    return (value) -> ExtIntSupplier.quiet(() -> doubleToIntFunction.applyAsInt(value)).getAsInt();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleToLongFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleToLongFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.DoubleToLongFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtDoubleToLongFunction<E extends Throwable> {
+  long applyAsLong(double value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static DoubleToLongFunction quiet(ExtDoubleToLongFunction<?> doubleToLongFunction) {
+    return (value) -> ExtLongSupplier.quiet(() -> doubleToLongFunction.applyAsLong(value)).getAsLong();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtDoubleUnaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtDoubleUnaryOperator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.DoubleUnaryOperator;
+
+public interface ExtDoubleUnaryOperator<E extends Throwable> {
+  double applyAsDouble(double operand) throws E;
+  
+  default ExtDoubleUnaryOperator<E> compose(ExtDoubleUnaryOperator<E> before) {
+    Objects.requireNonNull(before);
+    return (operand) -> applyAsDouble(before.applyAsDouble(operand));
+  }
+  
+  default ExtDoubleUnaryOperator<E> andThen(ExtDoubleUnaryOperator<E> after) {
+    Objects.requireNonNull(after);
+    return (operand) -> after.applyAsDouble(applyAsDouble(operand));
+  }
+  
+  static DoubleUnaryOperator quiet(ExtDoubleUnaryOperator<?> doubleUnaryOperator) {
+    return (operand) -> ExtDoubleSupplier.quiet(() -> doubleUnaryOperator.applyAsDouble(operand)).getAsDouble();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import com.facebook.util.ExtSupplier;
+import java.util.Objects;
+import java.util.function.Function;
+
+public interface ExtFunction<T, R, E extends Throwable> {
+  R apply(T t) throws E;
+  
+  default <V> ExtFunction<V, R, E> compose(ExtFunction<? super V, ? extends T, E> before) {
+    Objects.requireNonNull(before);
+    return (v) -> apply(before.apply(v));
+  }
+  
+  default <V> ExtFunction<T, V, E> andThen(ExtFunction<? super R, ? extends V, E> after) {
+    Objects.requireNonNull(after);
+    return (t) -> after.apply(apply(t));
+  }
+  
+  static <T, R> Function<T, R> quiet(ExtFunction<T, R, ?> function) {
+    return (t) -> ExtSupplier.quiet(() -> function.apply(t)).get();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtIntBinaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntBinaryOperator.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.IntBinaryOperator;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntBinaryOperator<E extends Throwable> {
+  int applyAsInt(int left, int right) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static IntBinaryOperator quiet(ExtIntBinaryOperator<?> intBinaryOperator) {
+    return (left, right) -> ExtIntSupplier.quiet(() -> intBinaryOperator.applyAsInt(left, right)).getAsInt();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntConsumer.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.Objects;
+import java.util.function.IntConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntConsumer<E extends Throwable> {
+  void accept(int value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  default ExtIntConsumer<E> andThen(ExtIntConsumer<E> after) {
+    Objects.requireNonNull(after);
+    return (t) -> {
+      accept(t);
+      after.accept(t);
+    };
+  }
+  
+  static IntConsumer quiet(ExtIntConsumer<?> intConsumer) {
+    return (value) -> ExtRunnable.quiet(() -> intConsumer.accept(value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntFunction.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtSupplier;
+import java.util.function.IntFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntFunction<R, E extends Throwable> {
+  R apply(int value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <R> IntFunction<R> quiet(ExtIntFunction<R, ?> intFunction) {
+    return (value) -> ExtSupplier.quiet(() -> intFunction.apply(value)).get();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntPredicate.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.IntPredicate;
+
+public interface ExtIntPredicate<E extends Throwable> {
+  boolean test(int value) throws E;
+  
+  default ExtIntPredicate<E> and(ExtIntPredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) && other.test(value);
+  }
+  
+  default ExtIntPredicate<E> negate() {
+    return (value) -> !test(value);
+  }
+  
+  default ExtIntPredicate<E> or(ExtIntPredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) || other.test(value);
+  }
+  
+  static IntPredicate quiet(ExtIntPredicate<?> intPredicate) {
+    return (value) -> ExtBooleanSupplier.quiet(() -> intPredicate.test(value)).getAsBoolean();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtIntSupplier.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntSupplier.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.util.function.IntSupplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntSupplier<E extends Throwable> {
+  int getAsInt() throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static IntSupplier quiet(ExtIntSupplier<?> intSupplier) {
+    return () -> {
+      try {
+        return intSupplier.getAsInt();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntToDoubleFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntToDoubleFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.IntToDoubleFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntToDoubleFunction<E extends Throwable> {
+  double applyAsDouble(int value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static IntToDoubleFunction quiet(ExtIntToDoubleFunction<?> intToDoubleFunction) {
+    return (value) -> ExtDoubleSupplier.quiet(() -> intToDoubleFunction.applyAsDouble(value)).getAsDouble();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntToLongFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntToLongFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.IntToLongFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtIntToLongFunction<E extends Throwable> {
+  long applyAsLong(int value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static IntToLongFunction quiet(ExtIntToLongFunction<?> intToLongFunction) {
+    return (value) -> ExtLongSupplier.quiet(() -> intToLongFunction.applyAsLong(value)).getAsLong();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtIntUnaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtIntUnaryOperator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.IntUnaryOperator;
+
+public interface ExtIntUnaryOperator<E extends Throwable> {
+  int applyAsInt(int operand) throws E;
+  
+  default ExtIntUnaryOperator<E> compose(ExtIntUnaryOperator<E> before) {
+    Objects.requireNonNull(before);
+    return (operand) -> applyAsInt(before.applyAsInt(operand));
+  }
+  
+  default ExtIntUnaryOperator<E> andThen(ExtIntUnaryOperator<E> after) {
+    Objects.requireNonNull(after);
+    return (operand) -> after.applyAsInt(applyAsInt(operand));
+  }
+  
+  static IntUnaryOperator quiet(ExtIntUnaryOperator<?> intUnaryOperator) {
+    return (operand) -> ExtIntSupplier.quiet(() -> intUnaryOperator.applyAsInt(operand)).getAsInt();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtLongBinaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongBinaryOperator.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.LongBinaryOperator;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongBinaryOperator<E extends Throwable> {
+  long applyAsLong(long left, long right) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static LongBinaryOperator quiet(ExtLongBinaryOperator<?> longBinaryOperator) {
+    return (left, right) -> ExtLongSupplier.quiet(() -> longBinaryOperator.applyAsLong(left, right)).getAsLong();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongConsumer.java
@@ -13,14 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.Objects;
+import java.util.function.LongConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongConsumer<E extends Throwable> {
+  void accept(long value) throws E;
+
+  default ExtLongConsumer<E> andThen(ExtLongConsumer<E> after) {
+    Objects.requireNonNull(after);
+    return (value) -> {
+      accept(value);
+      after.accept(value);
+    };
+  }
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static LongConsumer quiet(ExtLongConsumer<?> longConsumer) {
+    return (value) -> ExtRunnable.quiet(() -> longConsumer.accept(value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongFunction.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtSupplier;
+import java.util.function.LongFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongFunction<R, E extends Throwable> {
+  R apply(long value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <R> LongFunction<R> quiet(ExtLongFunction<R, ?> longFunction) {
+    return (value) -> ExtSupplier.quiet(() -> longFunction.apply(value)).get();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongPredicate.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.LongPredicate;
+
+public interface ExtLongPredicate<E extends Throwable> {
+  boolean test(long value) throws E;
+  
+  default ExtLongPredicate<E> and(ExtLongPredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) && other.test(value);
+  }
+  
+  default ExtLongPredicate<E> negate() {
+    return (value) -> !test(value);
+  }
+  
+  default ExtLongPredicate<E> or(ExtLongPredicate<E> other) {
+    Objects.requireNonNull(other);
+    return (value) -> test(value) || other.test(value);
+  }
+  
+  static LongPredicate quiet(ExtLongPredicate<?> longPredicate) {
+    return (value) -> ExtBooleanSupplier.quiet(() -> longPredicate.test(value)).getAsBoolean();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtLongSupplier.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongSupplier.java
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.util.function.LongSupplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongSupplier<E extends Throwable> {
+  long getAsLong() throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static LongSupplier quiet(ExtLongSupplier<?> longSupplier) {
+    return () -> {
+      try {
+        return longSupplier.getAsLong();
+      } catch (Error | RuntimeException e) {
+        throw e;
+      } catch (Throwable e) {
+        throw new UncheckedCheckedException(e);
+      }
+    };
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongToDoubleFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongToDoubleFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.LongToDoubleFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongToDoubleFunction<E extends Throwable> {
+  double applyAsDouble(long value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static LongToDoubleFunction quiet(ExtLongToDoubleFunction<?> longToDoubleFunction) {
+    return (value) -> ExtDoubleSupplier.quiet(() -> longToDoubleFunction.applyAsDouble(value)).getAsDouble();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongToIntFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongToIntFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.LongToIntFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtLongToIntFunction<E extends Throwable> {
+  int applyAsInt(long value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static LongToIntFunction quiet(ExtLongToIntFunction<?> longToIntFunction) {
+    return (value) -> ExtIntSupplier.quiet(() -> longToIntFunction.applyAsInt(value)).getAsInt();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtLongUnaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtLongUnaryOperator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.LongUnaryOperator;
+
+public interface ExtLongUnaryOperator<E extends Throwable> {
+  long applyAsLong(long operand) throws E;
+  
+  default ExtLongUnaryOperator<E> compose(ExtLongUnaryOperator<E> before) {
+    Objects.requireNonNull(before);
+    return (operand) -> applyAsLong(before.applyAsLong(operand));
+  }
+  
+  default ExtLongUnaryOperator<E> andThen(ExtLongUnaryOperator<E> after) {
+    Objects.requireNonNull(after);
+    return (operand) -> after.applyAsLong(applyAsLong(operand));
+  }
+  
+  static LongUnaryOperator quiet(ExtLongUnaryOperator<?> longUnaryOperator) {
+    return (operand) -> ExtLongSupplier.quiet(() -> longUnaryOperator.applyAsLong(operand)).getAsLong();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtObjDoubleConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtObjDoubleConsumer.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.function.ObjDoubleConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtObjDoubleConsumer<T, E extends Throwable> {
+  void accept(T t, double value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ObjDoubleConsumer<T> quiet(ExtObjDoubleConsumer<T, ?> objDoubleConsumer) {
+    return (t, value) -> ExtRunnable.quiet(() -> objDoubleConsumer.accept(t, value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtObjIntConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtObjIntConsumer.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.function.ObjIntConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtObjIntConsumer<T, E extends Throwable> {
+  void accept(T t, int value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ObjIntConsumer<T> quiet(ExtObjIntConsumer<T, ?> objIntConsumer) {
+    return (t, value) -> ExtRunnable.quiet(() -> objIntConsumer.accept(t, value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtObjLongConsumer.java
+++ b/util/src/main/java/com/facebook/util/function/ExtObjLongConsumer.java
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.ExtRunnable;
+import java.util.function.ObjLongConsumer;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtObjLongConsumer<T, E extends Throwable> {
+  void accept(T t, long value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ObjLongConsumer<T> quiet(ExtObjLongConsumer<T, ?> objLongConsumer) {
+    return (t, value) -> ExtRunnable.quiet(() -> objLongConsumer.accept(t, value)).run();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtPredicate.java
+++ b/util/src/main/java/com/facebook/util/function/ExtPredicate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util.function;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+public interface ExtPredicate<T, E extends Throwable> {
+  boolean test(T t) throws E;
+  
+  default ExtPredicate<T, E> and(ExtPredicate<? super T, E> other) {
+    Objects.requireNonNull(other);
+    return (t) -> test(t) && other.test(t);
+  }
+  
+  default ExtPredicate<T, E> negate() {
+    return (t) -> !test(t);
+  }
+  
+  default ExtPredicate<T, E> or(ExtPredicate<? super T, E> other) {
+    Objects.requireNonNull(other);
+    return (t) -> test(t) || other.test(t);
+  }
+  
+  static <T> Predicate<T> quiet(ExtPredicate<T, ?> predicate) {
+    return (t) -> ExtBooleanSupplier.quiet(() -> predicate.test(t)).getAsBoolean();
+  }
+}

--- a/util/src/main/java/com/facebook/util/function/ExtToDoubleBiFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToDoubleBiFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToDoubleBiFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToDoubleBiFunction<T, U, E extends Throwable> {
+  double applyAsDouble(T t, U u) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T, U> ToDoubleBiFunction<T, U> quiet(ExtToDoubleBiFunction<T, U, ?> toDoubleBiFunction) {
+    return (t, u) -> ExtDoubleSupplier.quiet(() -> toDoubleBiFunction.applyAsDouble(t, u)).getAsDouble();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtToDoubleFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToDoubleFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToDoubleFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToDoubleFunction<T, E extends Throwable> {
+  double applyAsDouble(T value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ToDoubleFunction<T> quiet(ExtToDoubleFunction<T, ?> toDoubleFunction) {
+    return (value) -> ExtDoubleSupplier.quiet(() -> toDoubleFunction.applyAsDouble(value)).getAsDouble();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtToIntBiFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToIntBiFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToIntBiFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToIntBiFunction<T, U, E extends Throwable> {
+  int applyAsInt(T t, U u) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T, U> ToIntBiFunction<T, U> quiet(ExtToIntBiFunction<T, U, ?> toIntBiFunction) {
+    return (t, u) -> ExtIntSupplier.quiet(() -> toIntBiFunction.applyAsInt(t, u)).getAsInt();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtToIntFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToIntFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToIntFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToIntFunction<T, E extends Throwable> {
+  int applyAsInt(T value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ToIntFunction<T> quiet(ExtToIntFunction<T, ?> toIntFunction) {
+    return (value) -> ExtIntSupplier.quiet(() -> toIntFunction.applyAsInt(value)).getAsInt();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtToLongBiFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToLongBiFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToLongBiFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToLongBiFunction<T, U, E extends Throwable> {
+  long applyAsLong(T t, U u) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T, U> ToLongBiFunction<T, U> quiet(ExtToLongBiFunction<T, U, ?> toLongBiFunction) {
+    return (t, u) -> ExtLongSupplier.quiet(() -> toLongBiFunction.applyAsLong(t, u)).getAsLong();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtToLongFunction.java
+++ b/util/src/main/java/com/facebook/util/function/ExtToLongFunction.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.ToLongFunction;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
+public interface ExtToLongFunction<T, E extends Throwable> {
+  long applyAsLong(T value) throws E;
   
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+  static <T> ToLongFunction<T> quiet(ExtToLongFunction<T, ?> toLongFunction) {
+    return (value) -> ExtLongSupplier.quiet(() -> toLongFunction.applyAsLong(value)).getAsLong();
   }
 }

--- a/util/src/main/java/com/facebook/util/function/ExtUnaryOperator.java
+++ b/util/src/main/java/com/facebook/util/function/ExtUnaryOperator.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import java.util.function.UnaryOperator;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public interface ExtUnaryOperator<T, E extends Throwable> extends ExtFunction<T, T, E> {
+  static <T> UnaryOperator<T> quiet(ExtUnaryOperator<T, ?> unaryOperator) {
+    return (a) -> ExtFunction.quiet(unaryOperator).apply(a);
   }
 }

--- a/util/src/main/java/com/facebook/util/function/package-info.java
+++ b/util/src/main/java/com/facebook/util/function/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * The classes in this package are utility functional interfaces that mirror java.util.function.*.
+ * They are extensions that allow the throwing of a typed exception.  To make these interfaces more useful,
+ * each interface has a static "quiet" builder, that constructs a java version of the interface that wraps
+ * checked exceptions in {@link com.facebook.util.exceptions.UncheckedCheckedException}s.  Here is an
+ * example of how to use one of these quiet factory methods:
+ * 
+ * <pre>
+ * {@code
+ * // Compile error because Files.delete() throws IOException
+ * Files.list(Paths.get("/path/to/some/dir")).forEach(Files::delete);
+ * // Quietly re-throws IOExceptions as UncheckedCheckedException
+ * Files.list(Paths.get("/path/to/some/dir")).forEach(ExtConsumer.quiet(Files::delete));
+ * }
+ * </pre>
+ */
+package com.facebook.util.function;

--- a/util/src/main/java/com/facebook/util/function/package-info.java
+++ b/util/src/main/java/com/facebook/util/function/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * The classes in this package are utility functional interfaces that mirror java.util.function.*.
  * They are extensions that allow the throwing of a typed exception.  To make these interfaces more useful,

--- a/util/src/test/java/com/facebook/util/TestExtRunnable.java
+++ b/util/src/test/java/com/facebook/util/TestExtRunnable.java
@@ -15,12 +15,11 @@
  */
 package com.facebook.util;
 
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtRunnable extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtRunnable.quiet(() -> { throw toThrow.get(); }).run();
   }
 }

--- a/util/src/test/java/com/facebook/util/TestExtSupplier.java
+++ b/util/src/test/java/com/facebook/util/TestExtSupplier.java
@@ -15,12 +15,11 @@
  */
 package com.facebook.util;
 
-import java.util.concurrent.Callable;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtSupplier extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtSupplier.quiet(() -> { throw toThrow.get(); }).get();
   }
 }

--- a/util/src/test/java/com/facebook/util/TestQuietFunctionBase.java
+++ b/util/src/test/java/com/facebook/util/TestQuietFunctionBase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.util;
+
+import com.facebook.util.exceptions.UncheckedCheckedException;
+import java.io.IOException;
+import java.util.function.Supplier;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public abstract class TestQuietFunctionBase {
+  @Test(groups = "fast")
+  public void testError() {
+    testExceptionType(Error.class, Error.class);
+  }
+  
+  @Test(groups = "fast")
+  public void testRuntimeException() {
+    testExceptionType(RuntimeException.class, RuntimeException.class);
+  }
+  
+  @Test(groups = "fast")
+  public void testCheckedException() {
+    testExceptionType(IOException.class, UncheckedCheckedException.class);
+  }
+  
+  protected abstract void throwFromQuiet(Supplier<? extends Throwable> toThrow);
+  
+  private void testExceptionType(Class<? extends Throwable> toThrow, Class<? extends Throwable> expectedCaughtType) {
+    try {
+      throwFromQuiet(() -> quietNewInstance(toThrow));
+    } catch (Throwable caught) {
+      Assert.assertEquals(caught.getClass(), expectedCaughtType);
+    }
+  }
+  
+  private <T> T quietNewInstance(Class<T> classToCreate) {
+    try {
+      return classToCreate.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/util/src/test/java/com/facebook/util/function/TestExtBooleanSupplier.java
+++ b/util/src/test/java/com/facebook/util/function/TestExtBooleanSupplier.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.TestQuietFunctionBase;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtBooleanSupplier extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtBooleanSupplier.quiet(() -> { throw toThrow.get(); }).getAsBoolean();
   }
 }

--- a/util/src/test/java/com/facebook/util/function/TestExtDoubleSupplier.java
+++ b/util/src/test/java/com/facebook/util/function/TestExtDoubleSupplier.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.TestQuietFunctionBase;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtDoubleSupplier extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtDoubleSupplier.quiet(() -> { throw toThrow.get(); }).getAsDouble();
   }
 }

--- a/util/src/test/java/com/facebook/util/function/TestExtIntSupplier.java
+++ b/util/src/test/java/com/facebook/util/function/TestExtIntSupplier.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.TestQuietFunctionBase;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtIntSupplier extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtIntSupplier.quiet(() -> { throw toThrow.get(); }).getAsInt();
   }
 }

--- a/util/src/test/java/com/facebook/util/function/TestExtLongSupplier.java
+++ b/util/src/test/java/com/facebook/util/function/TestExtLongSupplier.java
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.util;
+package com.facebook.util.function;
 
-import java.util.concurrent.Callable;
+import com.facebook.util.TestQuietFunctionBase;
+import java.util.function.Supplier;
 
-public interface ExtCallable<V, E extends Throwable> {
-  V call() throws E;
-  
-  static <V> Callable<V> quiet(ExtCallable<V, ?> callable) {
-    return () -> ExtSupplier.quiet(() -> callable.call()).get();
+public class TestExtLongSupplier extends TestQuietFunctionBase {
+  @Override
+  protected void throwFromQuiet(Supplier<? extends Throwable> toThrow) {
+    ExtLongSupplier.quiet(() -> { throw toThrow.get(); }).getAsLong();
   }
 }


### PR DESCRIPTION
This change will add Ext versions of all interfaces under java.util.function.  These interfaces have the extended ability to throw a typed exception.  This change also adds static "quiet" conversion methods to the interfaces to convert from a checked-throwing interface to the standard java.util.function interfaces.  The package-info.java file has an example of how these quiet methods are useful.