### PR TITLE
Safe publication

### DIFF
--- a/testing/src/main/java/com/facebook/testing/LoopInputStream.java
+++ b/testing/src/main/java/com/facebook/testing/LoopInputStream.java
@@ -27,7 +27,7 @@ public class LoopInputStream extends InputStream {
   private final Factory<InputStream> streamFactory;
   private final AtomicBoolean stop = new AtomicBoolean(false);
   private final AtomicInteger loopCount = new AtomicInteger(0);
-  private InputStream inputStream;
+  private volatile InputStream inputStream;
 
 
   public LoopInputStream(


### PR DESCRIPTION
Hi.

I suppose that without keyword volatile you can get NullPointException while accessing to LoopInputStream from several threads.

`LoopInputStream instance;`
Thread1
    `instance = new LoopInputStream(streamFactory);`
Thread2
 ```
  if(instance !=null){
      instance.read();
   }
```
Let's construct available execution
```
initialize_memory(instance)
  \--po-->final_write(instance.streamFactory, streamFactory)
                \--po-->write(inputStream, not null value)
                              \--po-->lock_monitor(loopCount)
                                            \--po-->some_action(loopCount)
                                                          \--po-->unlock_monitor(loopCount)
                                                                       \--po-->publish(instance)
----------------------------end of Thread1 execution, start Thread2-------------------
                                                                                \---->read(instance, not null)
                                                                                        \--po-->lock_monitor(instance)
                                                                                           \--po--> read(inputStream, null)
                                                                                              \--po-->unlock_monitor(loopCount)
```
which transform to
```
initialize_memory(instance)
  \--hb-->final_write(instance.streamFactory, streamFactory)
                \--hb-->write(inputStream, not null value)
                              \--hb-->lock_monitor(loopCount)
                                            \--hb-->some_action(loopCount)
                                                          \--hb-->unlock_monitor(loopCount)
                                                                       \--hb-->publish(instance)
                                                                                \---->read(instance, null)
                                                                                        \--hb-->lock_monitor(instance)
                                                                                           \--hb--> read(inputStream, null)
                                                                                              \--hb-->unlock_monitor(loopCount)
```
And as you can see there is not any HB edge between write inputStream and read inputStream.
We can't see any HB edge because acquiring monitor on "instance" and "loopCount" in single thread not in both.
So we can read instance == null